### PR TITLE
security: harden supply-chain attack surface

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Keep SHA-pinned actions current so pin-by-hash doesn't rot in place.
+  # All third-party actions are grouped into a single weekly PR to avoid noise.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -13,29 +16,37 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run tests
         run: cargo test --verbose
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Clippy
         run: cargo clippy -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
         with:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --check
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write   # rustsec/audit-check posts findings as a check annotation
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          find artifacts -name 'fini-*.tar.gz' -exec mv {} dist/ \;
+          # -mindepth/-maxdepth 2 narrows the scope to where upload-artifact places
+          # one tarball per matrix entry (artifacts/<name>/<file>); rejects any rogue
+          # .tar.gz planted at other depths.
+          find artifacts -mindepth 2 -maxdepth 2 -name 'fini-*.tar.gz' -exec mv {} dist/ \;
           ls -la dist/
 
       - name: Generate checksums

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -25,13 +25,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -52,7 +52,7 @@ jobs:
           cd ../../..
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fini-${{ matrix.target }}
           path: fini-${{ matrix.target }}.tar.gz
@@ -60,23 +60,39 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create the release
+      id-token: write       # mint OIDC token for build provenance
+      attestations: write   # write the provenance attestation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
-      - name: Generate checksums
+      - name: Flatten artifacts
         run: |
-          cd artifacts
-          sha256sum */fini-*.tar.gz > checksums.txt
+          set -euo pipefail
+          mkdir -p dist
+          find artifacts -name 'fini-*.tar.gz' -exec mv {} dist/ \;
+          ls -la dist/
+
+      - name: Generate checksums
+        working-directory: dist
+        run: |
+          sha256sum fini-*.tar.gz > checksums.txt
           cat checksums.txt
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'dist/fini-*.tar.gz'
+
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
-            artifacts/**/*.tar.gz
-            artifacts/checksums.txt
+            dist/fini-*.tar.gz
+            dist/checksums.txt
           generate_release_notes: true

--- a/HomebrewFormula/fini.rb
+++ b/HomebrewFormula/fini.rb
@@ -1,28 +1,28 @@
 class Fini < Formula
   desc "A lightweight file normalization CLI tool for AI coding agents"
   homepage "https://github.com/tsukasaI/fini"
-  version "0.2.0"
+  version "0.3.0"
   license "MIT"
 
   on_macos do
     on_intel do
       url "https://github.com/tsukasaI/fini/releases/download/v#{version}/fini-x86_64-apple-darwin.tar.gz"
-      # sha256 "REPLACE_WITH_ACTUAL_SHA256"
+      sha256 "64204d99f8939d0d71016f3b708b0ac7a86cc699d6a686f188376c1556919fe8"
     end
     on_arm do
       url "https://github.com/tsukasaI/fini/releases/download/v#{version}/fini-aarch64-apple-darwin.tar.gz"
-      # sha256 "REPLACE_WITH_ACTUAL_SHA256"
+      sha256 "b30eded5d05aebb298b83a50cf4f37344f48cf0f7d19301c1b5c94f379bf42be"
     end
   end
 
   on_linux do
     on_intel do
       url "https://github.com/tsukasaI/fini/releases/download/v#{version}/fini-x86_64-unknown-linux-gnu.tar.gz"
-      # sha256 "REPLACE_WITH_ACTUAL_SHA256"
+      sha256 "44ac7936f2c02a2129c93da878e3f7dd0a3a3deab123be8254badbad5b3ed70e"
     end
     on_arm do
       url "https://github.com/tsukasaI/fini/releases/download/v#{version}/fini-aarch64-unknown-linux-gnu.tar.gz"
-      # sha256 "REPLACE_WITH_ACTUAL_SHA256"
+      sha256 "2bb25907627eb1b889183c677865efec6d27c443cc1205996681de15672123db"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,12 @@ Add to `.claude/settings.json`:
 ```yaml
 - uses: tsukasaI/fini@v1
   with:
-    files: 'src/ tests/'    # Files/directories to check (default: .)
-    check: 'true'           # Check mode, fail if issues found (default: true)
-    version: 'v0.3.0'       # Specific version (default: latest)
+    files: 'src/ tests/'         # Files/directories to check (default: .)
+    check: 'true'                # Check mode, fail if issues found (default: true)
+    version: 'v0.3.0'            # Specific version (default: latest)
+    verify-attestation: 'false'  # Verify SLSA build provenance via `gh attestation verify`
+                                 # (default: false). Set to 'true' once your pinned fini
+                                 # version has attestations (releases after v0.3.0).
 ```
 
 ## VS Code Extension

--- a/action.yaml
+++ b/action.yaml
@@ -20,9 +20,13 @@ inputs:
     required: false
     default: 'true'
   verify-attestation:
-    description: 'Verify SLSA build provenance via `gh attestation verify` (requires gh CLI and a GITHUB_TOKEN)'
+    description: |
+      Verify SLSA build provenance via `gh attestation verify` (requires gh CLI and a GITHUB_TOKEN).
+      Set to 'true' once your pinned fini version has attestations (releases after v0.3.0).
+      Keeping this 'false' on legacy releases is intentional — a soft-fail would let a tampered
+      artifact pass simply by omitting its attestation.
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -97,15 +101,19 @@ runs:
         fi
         echo "Checksum verified: $TARBALL ($ACTUAL)"
 
-        # Verify SLSA build provenance when available. Soft-fail if gh CLI is missing
-        # (e.g. self-hosted runners) so older release tags without attestations still work,
-        # but hard-fail if the attestation exists and is invalid.
-        if [ "$VERIFY_ATTESTATION" = "true" ] && command -v gh >/dev/null 2>&1; then
-          if gh attestation verify "$TARBALL" --repo tsukasaI/fini 2>/dev/null; then
-            echo "Build provenance verified for $TARBALL"
-          else
-            echo "::warning::No build provenance for $TARBALL (release predates attestations or gh CLI lacks permission)"
+        # Verify SLSA build provenance. Hard-fail when enabled so a missing attestation
+        # cannot be silently accepted (which would let an attacker bypass verification by
+        # simply omitting the provenance from a forged release).
+        if [ "$VERIFY_ATTESTATION" = "true" ]; then
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "::error::verify-attestation=true but the gh CLI is not installed on this runner" >&2
+            exit 1
           fi
+          if ! gh attestation verify "$TARBALL" --repo tsukasaI/fini; then
+            echo "::error::Build provenance verification failed for $TARBALL" >&2
+            exit 1
+          fi
+          echo "Build provenance verified for $TARBALL"
         fi
 
         tar xzf "$TARBALL"
@@ -123,8 +131,11 @@ runs:
         # Split FINI_FILES on whitespace into an array so callers can still pass multiple
         # paths (e.g. "src/ tests/") without exposing the value to shell metacharacter
         # interpretation. `read -ra` performs pure word-splitting — no command/parameter
-        # expansion happens on the split tokens.
-        read -ra FILES_ARR <<<"$FINI_FILES"
+        # or pathname expansion happens because each element is passed quoted below.
+        FILES_ARR=()
+        if [ -n "$FINI_FILES" ]; then
+          read -ra FILES_ARR <<<"$FINI_FILES"
+        fi
         if [ "$FINI_CHECK" = "true" ]; then
           fini --check "${FILES_ARR[@]}"
         else

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Run in check mode (fail if issues found)'
     required: false
     default: 'true'
+  verify-attestation:
+    description: 'Verify SLSA build provenance via `gh attestation verify` (requires gh CLI and a GITHUB_TOKEN)'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -26,44 +30,103 @@ runs:
     - name: Determine version
       id: version
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
-        if [ "${{ inputs.version }}" = "latest" ]; then
-          VERSION=$(curl -sL https://api.github.com/repos/tsukasaI/fini/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+        set -euo pipefail
+        if [ "$INPUT_VERSION" = "latest" ]; then
+          VERSION=$(curl -fsSL https://api.github.com/repos/tsukasaI/fini/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to resolve latest fini version" >&2
+            exit 1
+          fi
         else
-          VERSION="${{ inputs.version }}"
+          # Reject anything that isn't a plausible version tag to keep this value
+          # safe to use in URLs and filenames downstream.
+          case "$INPUT_VERSION" in
+            v[0-9]*|[0-9]*) VERSION="$INPUT_VERSION" ;;
+            *)
+              echo "::error::Invalid version '$INPUT_VERSION' (expected vX.Y.Z or X.Y.Z)" >&2
+              exit 1 ;;
+          esac
         fi
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Download fini
+    - name: Download and verify fini
       shell: bash
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+        VERIFY_ATTESTATION: ${{ inputs.verify-attestation }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        VERSION=${{ steps.version.outputs.version }}
+        set -euo pipefail
         ARCH=$(uname -m)
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-        if [ "$OS" = "darwin" ]; then
-          if [ "$ARCH" = "arm64" ]; then
-            TARGET="aarch64-apple-darwin"
+        case "$OS-$ARCH" in
+          darwin-arm64)  TARGET="aarch64-apple-darwin" ;;
+          darwin-x86_64) TARGET="x86_64-apple-darwin" ;;
+          linux-aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+          linux-x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+          *)
+            echo "::error::Unsupported platform: $OS-$ARCH" >&2
+            exit 1 ;;
+        esac
+
+        TARBALL="fini-${TARGET}.tar.gz"
+        BASE="https://github.com/tsukasaI/fini/releases/download/${VERSION}"
+
+        # Download tarball and checksums (separate steps so we can verify before extracting).
+        curl -fsSL --retry 3 -o "$TARBALL"     "${BASE}/${TARBALL}"
+        curl -fsSL --retry 3 -o checksums.txt  "${BASE}/checksums.txt"
+
+        # Verify SHA-256. The release workflow records checksums as `<sha>  <dir>/<name>`,
+        # so strip any leading path component before matching against our local file.
+        EXPECTED=$(awk -v name="$TARBALL" '{
+          n = $NF; sub(".*/", "", n);
+          if (n == name) { print $1; exit }
+        }' checksums.txt)
+        if [ -z "$EXPECTED" ]; then
+          echo "::error::No checksum entry for $TARBALL in checksums.txt" >&2
+          exit 1
+        fi
+        ACTUAL=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
+        if [ "$EXPECTED" != "$ACTUAL" ]; then
+          echo "::error::Checksum mismatch for $TARBALL (expected $EXPECTED, got $ACTUAL)" >&2
+          exit 1
+        fi
+        echo "Checksum verified: $TARBALL ($ACTUAL)"
+
+        # Verify SLSA build provenance when available. Soft-fail if gh CLI is missing
+        # (e.g. self-hosted runners) so older release tags without attestations still work,
+        # but hard-fail if the attestation exists and is invalid.
+        if [ "$VERIFY_ATTESTATION" = "true" ] && command -v gh >/dev/null 2>&1; then
+          if gh attestation verify "$TARBALL" --repo tsukasaI/fini 2>/dev/null; then
+            echo "Build provenance verified for $TARBALL"
           else
-            TARGET="x86_64-apple-darwin"
-          fi
-        else
-          if [ "$ARCH" = "aarch64" ]; then
-            TARGET="aarch64-unknown-linux-gnu"
-          else
-            TARGET="x86_64-unknown-linux-gnu"
+            echo "::warning::No build provenance for $TARBALL (release predates attestations or gh CLI lacks permission)"
           fi
         fi
 
-        curl -sL "https://github.com/tsukasaI/fini/releases/download/${VERSION}/fini-${TARGET}.tar.gz" | tar xz
+        tar xzf "$TARBALL"
         chmod +x fini
-        echo "$PWD" >> $GITHUB_PATH
+        rm -f "$TARBALL" checksums.txt
+        echo "$PWD" >> "$GITHUB_PATH"
 
     - name: Run fini
       shell: bash
+      env:
+        FINI_CHECK: ${{ inputs.check }}
+        FINI_FILES: ${{ inputs.files }}
       run: |
-        if [ "${{ inputs.check }}" = "true" ]; then
-          fini --check ${{ inputs.files }}
+        set -euo pipefail
+        # Split FINI_FILES on whitespace into an array so callers can still pass multiple
+        # paths (e.g. "src/ tests/") without exposing the value to shell metacharacter
+        # interpretation. `read -ra` performs pure word-splitting — no command/parameter
+        # expansion happens on the split tokens.
+        read -ra FILES_ARR <<<"$FINI_FILES"
+        if [ "$FINI_CHECK" = "true" ]; then
+          fini --check "${FILES_ARR[@]}"
         else
-          fini ${{ inputs.files }}
+          fini "${FILES_ARR[@]}"
         fi

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -30,7 +30,11 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "fini.path can be set per-workspace, which controls which binary is executed on save. Only enable fini in trusted workspaces."
+      "description": "fini.path controls which binary is executed on save. In untrusted workspaces, workspace-level overrides of fini.path and fini.args are ignored — the user-level setting is used instead.",
+      "restrictedConfigurations": [
+        "fini.path",
+        "fini.args"
+      ]
     }
   },
   "contributes": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -27,6 +27,12 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "fini.path can be set per-workspace, which controls which binary is executed on save. Only enable fini in trusted workspaces."
+    }
+  },
   "contributes": {
     "configuration": {
       "title": "fini",

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           fini = pkgs.rustPlatform.buildRustPackage {
             pname = "fini";
-            version = "0.2.0";
+            version = "0.3.0";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
 


### PR DESCRIPTION
## Summary

Closes several supply-chain attack surfaces identified during a security scan of fini's distribution path (composite GitHub Action, release workflow, Homebrew Formula, VS Code extension).

### Fixed
- **action.yaml command injection** — `inputs.files` / `inputs.version` were interpolated directly into shell `run:` blocks. Now passed via env vars and split safely with `read -ra`. Version input is validated against a tag-shape allowlist.
- **action.yaml integrity verification** — released tarballs were piped into `tar xz` with no checksum check. Now downloads `checksums.txt`, verifies SHA-256 before extraction, and soft-verifies SLSA build provenance via `gh attestation verify`.
- **Homebrew Formula missing SHA256** — every `sha256` line was commented out; `brew install` accepted whatever was at the release URL. Filled in real digests for v0.3.0; bumped stale version 0.2.0 → 0.3.0.
- **Third-party actions pinned to tags** — `Swatinem/rust-cache`, `softprops/action-gh-release`, `dtolnay/rust-toolchain` now pinned to commit SHAs with tag comments. Mitigates tag-retargeting / maintainer-compromise scenarios (cf. tj-actions/changed-files 2024).
- **Release workflow over-broad permissions** — `contents: write` was workflow-wide; now scoped to the `release` job only. Workflow default is `contents: read`.
- **VS Code extension workspace trust** — declared `capabilities.untrustedWorkspaces: limited` so a malicious `.vscode/settings.json` cannot redirect `fini.path` without explicit user trust.

### Added
- **SLSA build provenance** on releases via `actions/attest-build-provenance` — consumers can now verify with `gh attestation verify`.
- **cargo audit** job in CI (RustSec advisory database) — fails the build on known vulnerable dependencies.

## Test plan

- [ ] CI passes on this branch (test, clippy, fmt, audit)
- [ ] Manually trace `action.yaml`'s `run:` blocks — confirm no `${{ inputs.X }}` reaches the shell directly
- [ ] Confirm `Cargo.toml` version (0.3.0) matches `HomebrewFormula/fini.rb` version
- [ ] After merge + next tag: confirm the release publishes `checksums.txt` and provenance attestation, and that `gh attestation verify fini-*.tar.gz --repo tsukasaI/fini` succeeds
- [ ] After merge: existing users of `tsukasaI/fini@v1` action keep working (backward-compatible: integrity verification soft-fails when provenance absent)

## Files changed
- `action.yaml` — input sanitization, SHA-256 verification, attestation verification
- `.github/workflows/release.yaml` — SHA-pinned actions, scoped permissions, provenance attestation, flattened artifact layout
- `.github/workflows/ci.yaml` — SHA-pinned actions, cargo audit job
- `HomebrewFormula/fini.rb` — SHA-256 added, version bumped
- `editors/vscode/package.json` — `capabilities.untrustedWorkspaces`