### PR TITLE
ci(release): add crates.io publish job with build provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,14 +112,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # No rust-cache here: --no-verify skips the build, so the cache buys nothing
+      # and a poisoned cache entry could substitute dependencies at publish time.
 
       - name: Verify Cargo.toml version matches tag
         run: |
           set -euo pipefail
+          # Strips the leading "v"; works for pre-release tags too
+          # (e.g. v0.4.0-rc1 -> 0.4.0-rc1, matched against Cargo.toml verbatim).
           TAG="${GITHUB_REF_NAME#v}"
           CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[0].version')
+            | jq -r '.packages[] | select(.name == "fini") | .version')
           if [ "$TAG" != "$CARGO_VERSION" ]; then
             echo "::error::Tag $GITHUB_REF_NAME does not match Cargo.toml version $CARGO_VERSION" >&2
             exit 1
@@ -152,12 +155,15 @@ jobs:
         run: cargo publish --locked --no-verify
 
       - name: Verify post-publish .crate hash unchanged
+        # If this fails, the crate is already on crates.io. The attestation
+        # may not cover the uploaded bytes — yank the version via
+        # `cargo yank --version <v>` and investigate before re-releasing.
         env:
           BEFORE: ${{ steps.hash.outputs.before }}
         run: |
           set -euo pipefail
           AFTER=$(sha256sum target/package/fini-*.crate | awk '{print $1}')
           if [ "$BEFORE" != "$AFTER" ]; then
-            echo "::error::.crate sha256 changed between attest and publish ($BEFORE -> $AFTER); attestation may not cover the published artifact" >&2
+            echo "::error::.crate sha256 changed between attest and publish ($BEFORE -> $AFTER); attestation may not cover the published artifact. Yank and investigate." >&2
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,8 @@ jobs:
       # No rust-cache here: --no-verify skips the build, so the cache buys nothing
       # and a poisoned cache entry could substitute dependencies at publish time.
 
-      - name: Verify Cargo.toml version matches tag
+      - name: Verify version and resolve crate path
+        id: prepare
         run: |
           set -euo pipefail
           # Strips the leading "v"; works for pre-release tags too
@@ -127,25 +128,30 @@ jobs:
             echo "::error::Tag $GITHUB_REF_NAME does not match Cargo.toml version $CARGO_VERSION" >&2
             exit 1
           fi
+          echo "version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "crate-path=target/package/fini-${CARGO_VERSION}.crate" >> "$GITHUB_OUTPUT"
 
+      # --dry-run produces target/package/fini-<version>.crate as a side
+      # effect and validates the publish path (manifest, registry metadata,
+      # build from the packaged tarball). cargo package alone would skip
+      # the publish-mode validation.
       - name: cargo publish --dry-run
         run: cargo publish --locked --dry-run
 
-      - name: cargo package
-        run: cargo package --locked
-
       - name: Record pre-publish hash
         id: hash
+        env:
+          CRATE: ${{ steps.prepare.outputs.crate-path }}
         run: |
           set -euo pipefail
-          BEFORE=$(sha256sum target/package/fini-*.crate | awk '{print $1}')
+          BEFORE=$(sha256sum "$CRATE" | awk '{print $1}')
           echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
-          echo "Pre-publish .crate sha256: $BEFORE"
+          echo "Pre-publish $CRATE sha256: $BEFORE"
 
       - name: Attest .crate
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: 'target/package/fini-*.crate'
+          subject-path: ${{ steps.prepare.outputs.crate-path }}
 
       - name: Publish to crates.io
         env:
@@ -160,10 +166,11 @@ jobs:
         # `cargo yank --version <v>` and investigate before re-releasing.
         env:
           BEFORE: ${{ steps.hash.outputs.before }}
+          CRATE: ${{ steps.prepare.outputs.crate-path }}
         run: |
           set -euo pipefail
-          AFTER=$(sha256sum target/package/fini-*.crate | awk '{print $1}')
+          AFTER=$(sha256sum "$CRATE" | awk '{print $1}')
           if [ "$BEFORE" != "$AFTER" ]; then
-            echo "::error::.crate sha256 changed between attest and publish ($BEFORE -> $AFTER); attestation may not cover the published artifact. Yank and investigate." >&2
+            echo "::error::$CRATE sha256 changed between attest and publish ($BEFORE -> $AFTER); attestation may not cover the published artifact. Yank and investigate." >&2
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,3 +99,65 @@ jobs:
             dist/fini-*.tar.gz
             dist/checksums.txt
           generate_release_notes: true
+
+  publish-crate:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # checkout only
+      id-token: write       # mint OIDC token for build provenance
+      attestations: write   # write the provenance attestation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Verify Cargo.toml version matches tag
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[0].version')
+          if [ "$TAG" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match Cargo.toml version $CARGO_VERSION" >&2
+            exit 1
+          fi
+
+      - name: cargo publish --dry-run
+        run: cargo publish --locked --dry-run
+
+      - name: cargo package
+        run: cargo package --locked
+
+      - name: Record pre-publish hash
+        id: hash
+        run: |
+          set -euo pipefail
+          BEFORE=$(sha256sum target/package/fini-*.crate | awk '{print $1}')
+          echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
+          echo "Pre-publish .crate sha256: $BEFORE"
+
+      - name: Attest .crate
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'target/package/fini-*.crate'
+
+      - name: Publish to crates.io
+        env:
+          # Token must be scoped to `publish-update` only (fini is already
+          # published, so `publish-new` is unnecessary).
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked --no-verify
+
+      - name: Verify post-publish .crate hash unchanged
+        env:
+          BEFORE: ${{ steps.hash.outputs.before }}
+        run: |
+          set -euo pipefail
+          AFTER=$(sha256sum target/package/fini-*.crate | awk '{print $1}')
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "::error::.crate sha256 changed between attest and publish ($BEFORE -> $AFTER); attestation may not cover the published artifact" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a `publish-crate` job to `.github/workflows/release.yaml`, gated on `needs: release`, so a `v*` tag now automates `cargo publish` after the GitHub Release succeeds.
- Attests the `.crate` with `actions/attest-build-provenance` (same fail-closed pattern as PR #1's tarballs), so the published crate is verifiable via `gh attestation verify`.
- Guards against drift: tag ↔ `Cargo.toml` version mismatch fails fast, and a pre/post SHA256 check on `target/package/*.crate` ensures the attested bytes are the bytes uploaded (`cargo publish` re-packages internally — packaging is deterministic, but we verify rather than trust).

Closes #3.

## Maintainer setup required before next tag
- Create a crates.io API token scoped to `publish-update` only (fini is already published; `publish-new` not needed).
- Add it as repo secret `CRATES_IO_TOKEN`.

## Test plan
- [x] \`cargo publish --locked --dry-run\` passes on the current tree.
- [x] \`cargo package --locked\` twice produces byte-identical \`.crate\` (SHA256 stable) — confirms post-publish hash check won't false-positive.
- [x] Workflow YAML parses; new job has \`needs: release\`, correct permissions (\`id-token: write\`, \`attestations: write\`), 10 steps.
- [ ] Real verification deferred to next release: cut \`v0.4.0\`, then \`cargo install fini@0.4.0\` works and \`gh attestation verify --owner tsukasaI <crate>\` succeeds.

## Out of scope
- Issue #2 (Homebrew auto-update) — deferred pending a decision on in-repo \`HomebrewFormula/\` vs. a separate \`homebrew-tap\` repo.
- Issue #4 (VS Code Marketplace) — separate follow-up PR.