### PR TITLE
fix(cli): fail closed on walker/IO errors, split exit codes, fix idempotency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,14 @@ Key design decisions:
 Fixes are applied in this sequence within `normalize_content()`:
 1. Line ending normalization (CRLF/CR → LF)
 2. Zero-width character removal (preserves BOM at position 0)
-3. Leading blank line removal
-4. Consecutive blank line limiting
-5. Code block remnant removal
+3. Code block remnant removal
+4. Leading blank line removal
+5. Consecutive blank line limiting
 6. Fullwidth space conversion (U+3000 → space)
 7. Trailing whitespace removal
 8. EOF newline normalization
+
+Code block remnant removal runs before the blank-line fixes so blank lines exposed by removing a fence (e.g. a fence at the top of the file, or blank lines split apart by a fence) are cleaned up in the same pass — otherwise `fini` fix output could fail an immediate `fini --check` (non-idempotent output).
 
 Then detections run: TODOs, FIXMEs, debug code, secrets, line length.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,19 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
         files_fixed: 0,
         files_with_problems: 0,
         warnings: 0,
+        errors: 0,
     };
 
-    let file_paths: Vec<_> = walk_paths(paths, &config.exclude_patterns)
-        .filter_map(|r| r.ok())
-        .collect();
+    let mut file_paths = vec![];
+    for entry in walk_paths(paths, &config.exclude_patterns)? {
+        match entry {
+            Ok(path) => file_paths.push(path),
+            Err(e) => {
+                eprintln!("Error walking path: {e}");
+                result.errors += 1;
+            }
+        }
+    }
     let progress = ProgressReporter::new(file_paths.len() as u64, ctx.show_progress);
 
     // Process files in parallel (read + normalize), collect results
@@ -95,9 +103,8 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
                 } else {
                     if normalize_result.has_changes() {
                         if let Err(e) = fs::write(path, &normalize_result.content) {
-                            if ctx.mode != OutputMode::Quiet {
-                                eprintln!("Error writing {}: {e}", path.display());
-                            }
+                            eprintln!("Error writing {}: {e}", path.display());
+                            result.errors += 1;
                             continue;
                         }
                         result.files_fixed += 1;
@@ -106,9 +113,8 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
                 }
             }
             FileOutcome::Error(e) => {
-                if ctx.mode != OutputMode::Quiet {
-                    eprintln!("Error processing {}: {e}", path.display());
-                }
+                eprintln!("Error processing {}: {e}", path.display());
+                result.errors += 1;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,9 @@ fn main() -> ExitCode {
 
     match run(&cli.paths, &config, &ctx) {
         Ok(result) => {
-            if config.check_only && result.has_problems() {
+            if result.has_errors() {
+                ExitCode::from(2)
+            } else if config.check_only && result.has_problems() {
                 ExitCode::from(1)
             } else {
                 ExitCode::SUCCESS
@@ -173,7 +175,7 @@ fn main() -> ExitCode {
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            ExitCode::from(1)
+            ExitCode::from(2)
         }
     }
 }
@@ -196,7 +198,7 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {
         eprintln!("Error reading stdin: {e}");
-        return ExitCode::from(1);
+        return ExitCode::from(2);
     }
 
     // Build normalize config
@@ -221,7 +223,7 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
     print!("{}", result.content);
     if let Err(e) = io::stdout().flush() {
         eprintln!("Error writing stdout: {e}");
-        return ExitCode::from(1);
+        return ExitCode::from(2);
     }
 
     ExitCode::SUCCESS

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -136,6 +136,12 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
         problems.extend(zw_problems);
     }
 
+    if config.fix_code_blocks {
+        let (fixed, code_block_problems) = remove_code_block_remnants(&result);
+        result = fixed;
+        problems.extend(code_block_problems);
+    }
+
     if config.remove_leading_blanks {
         let (fixed, leading_problems) = remove_leading_blank_lines(&result);
         result = fixed;
@@ -146,12 +152,6 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
         let (fixed, blank_problems) = limit_consecutive_blank_lines(&result, max);
         result = fixed;
         problems.extend(blank_problems);
-    }
-
-    if config.fix_code_blocks {
-        let (fixed, code_block_problems) = remove_code_block_remnants(&result);
-        result = fixed;
-        problems.extend(code_block_problems);
     }
 
     let (fixed, fullwidth_problems) = fix_fullwidth_spaces(&result);
@@ -854,6 +854,73 @@ mod tests {
         let input = "\n\n```rust\nfn main() {\n    let x\u{200B} = 1;\n\n\n\n}\n```\n";
         let result = normalize_content(input, &config);
         assert_eq!(result.content, "fn main() {\n    let x = 1;\n\n}\n");
+    }
+
+    #[test]
+    fn test_fix_output_is_idempotent_with_blank_limit_and_code_blocks() {
+        // Regression test for issue #33: max_blank_lines + fix_code_blocks must be
+        // idempotent — running normalize_content twice should reach a fixed point
+        // on the first pass, so `fini` followed by `fini --check` never fails.
+        let config = NormalizeConfig {
+            max_blank_lines: Some(1),
+            fix_code_blocks: true,
+            ..NormalizeConfig::default()
+        };
+        let input = "a\n\n```py\n\nb\n";
+        let first = normalize_content(input, &config);
+        assert_eq!(first.content, "a\n\nb\n");
+
+        let second = normalize_content(&first.content, &config);
+        assert!(!second.has_changes());
+        assert!(second.problems.is_empty());
+    }
+
+    #[test]
+    fn test_idempotency_matrix_across_fix_flag_combinations() {
+        // Broader regression coverage for issue #33's bug class: any combination
+        // of blank-line/code-block fix flags applied to adversarial inputs (a
+        // fence at the very start/end of the file, fences surrounded by blank
+        // lines, CRLF mixed with trailing whitespace around a fence) must reach
+        // a fixed point after a single normalize_content pass.
+        let inputs = [
+            "```rust\nfn main() {}\n```\n",
+            "\n\n```py\ncode\n```\n\nafter\n",
+            "before\n```py\n\ncode\n\n```\nafter\n",
+            "```\ncode\n```\n\n\n\nmore\n",
+            "line1\r\n\r\n```js\r\ncode   \r\n```\r\n\r\nline2\r\n",
+            "\n\n\n```\ncode\n```\n",
+        ];
+
+        for &max_blank_lines in &[None, Some(0), Some(1), Some(2)] {
+            for &fix_code_blocks in &[false, true] {
+                for &remove_leading_blanks in &[false, true] {
+                    let config = NormalizeConfig {
+                        max_blank_lines,
+                        fix_code_blocks,
+                        remove_leading_blanks,
+                        ..NormalizeConfig::default()
+                    };
+
+                    for input in &inputs {
+                        let first = normalize_content(input, &config);
+                        let second = normalize_content(&first.content, &config);
+                        assert!(
+                            !second.has_changes(),
+                            "not idempotent for input {input:?} with config {config:?}: \
+                             {:?} -> {:?}",
+                            first.content,
+                            second.content
+                        );
+                        assert!(
+                            second.problems.iter().all(|p| p.kind.is_detection_only()),
+                            "leftover fixable problems for input {input:?} with config \
+                             {config:?}: {:?}",
+                            second.problems
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -39,11 +39,16 @@ pub struct RunResult {
     pub files_fixed: usize,
     pub files_with_problems: usize,
     pub warnings: usize,
+    pub errors: usize,
 }
 
 impl RunResult {
     pub fn has_problems(&self) -> bool {
         self.files_with_problems > 0
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.errors > 0
     }
 }
 
@@ -209,16 +214,28 @@ pub fn print_summary(result: &RunResult, config: &Config, ctx: &OutputContext) {
     }
 
     if config.check_only {
-        if result.files_with_problems > 0 {
+        if result.files_with_problems > 0 || result.errors > 0 {
             println!();
-            println!(
-                "{}{} files with problems{}",
-                ctx.colors.error,
-                result.files_with_problems,
-                ctx.colors.reset()
-            );
+            let mut parts = vec![];
+            if result.files_with_problems > 0 {
+                parts.push(format!(
+                    "{}{} files with problems{}",
+                    ctx.colors.error,
+                    result.files_with_problems,
+                    ctx.colors.reset()
+                ));
+            }
+            if result.errors > 0 {
+                parts.push(format!(
+                    "{}{} errors{}",
+                    ctx.colors.error,
+                    result.errors,
+                    ctx.colors.reset()
+                ));
+            }
+            println!("{}", parts.join(", "));
         }
-    } else if result.files_fixed > 0 || result.warnings > 0 {
+    } else if result.files_fixed > 0 || result.warnings > 0 || result.errors > 0 {
         println!();
         let mut parts = vec![];
         if result.files_fixed > 0 {
@@ -234,6 +251,14 @@ pub fn print_summary(result: &RunResult, config: &Config, ctx: &OutputContext) {
                 "{}{} warnings{}",
                 ctx.colors.warning,
                 result.warnings,
+                ctx.colors.reset()
+            ));
+        }
+        if result.errors > 0 {
+            parts.push(format!(
+                "{}{} errors{}",
+                ctx.colors.error,
+                result.errors,
                 ctx.colors.reset()
             ));
         }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -6,10 +6,15 @@ use std::path::PathBuf;
 /// Walk paths and yield file paths, respecting gitignore and custom exclude patterns.
 ///
 /// Exclude patterns use gitignore-style glob syntax (e.g., "vendor/", "*.min.js").
+///
+/// Returns `Err` immediately for fatal configuration errors (e.g. an invalid exclude
+/// pattern) so callers can fail closed instead of silently walking with no excludes.
+/// Once walking starts, per-entry errors (e.g. permission-denied on a subdirectory)
+/// are yielded as `Err` items in the iterator rather than aborting the whole walk.
 pub fn walk_paths(
     paths: &[String],
     exclude_patterns: &[String],
-) -> impl Iterator<Item = io::Result<PathBuf>> {
+) -> io::Result<impl Iterator<Item = io::Result<PathBuf>>> {
     let mut all_files = vec![];
 
     for path in paths {
@@ -25,16 +30,14 @@ pub fn walk_paths(
             for pattern in exclude_patterns {
                 // OverrideBuilder uses inverted ! semantics:
                 // !pattern = exclude, pattern = whitelist
-                if let Err(e) = overrides.add(&format!("!{pattern}")) {
-                    all_files.push(Err(io::Error::other(format!(
-                        "invalid exclude pattern '{pattern}': {e}"
-                    ))));
-                    return all_files.into_iter();
-                }
+                overrides.add(&format!("!{pattern}")).map_err(|e| {
+                    io::Error::other(format!("invalid exclude pattern '{pattern}': {e}"))
+                })?;
             }
-            if let Ok(built) = overrides.build() {
-                builder.overrides(built);
-            }
+            let built = overrides
+                .build()
+                .map_err(|e| io::Error::other(format!("failed to build exclude patterns: {e}")))?;
+            builder.overrides(built);
         }
 
         for entry in builder.build() {
@@ -51,7 +54,7 @@ pub fn walk_paths(
         }
     }
 
-    all_files.into_iter()
+    Ok(all_files.into_iter())
 }
 
 #[cfg(test)]
@@ -67,7 +70,7 @@ mod tests {
         fs::write(&file_path, "hello").unwrap();
 
         let paths = vec![file_path.to_string_lossy().to_string()];
-        let files: Vec<_> = walk_paths(&paths, &[]).collect();
+        let files: Vec<_> = walk_paths(&paths, &[]).unwrap().collect();
 
         assert_eq!(files.len(), 1);
         assert!(files[0].is_ok());
@@ -81,7 +84,10 @@ mod tests {
         fs::write(dir.path().join("subdir/file2.txt"), "content2").unwrap();
 
         let paths = vec![dir.path().to_string_lossy().to_string()];
-        let files: Vec<_> = walk_paths(&paths, &[]).filter_map(|r| r.ok()).collect();
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
 
         assert_eq!(files.len(), 2);
     }
@@ -93,7 +99,10 @@ mod tests {
         fs::write(dir.path().join(".hidden"), "hidden").unwrap();
 
         let paths = vec![dir.path().to_string_lossy().to_string()];
-        let files: Vec<_> = walk_paths(&paths, &[]).filter_map(|r| r.ok()).collect();
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
 
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("visible.txt"));
@@ -107,7 +116,10 @@ mod tests {
         fs::write(dir.path().join(".git/config"), "git config").unwrap();
 
         let paths = vec![dir.path().to_string_lossy().to_string()];
-        let files: Vec<_> = walk_paths(&paths, &[]).filter_map(|r| r.ok()).collect();
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
 
         assert_eq!(files.len(), 1);
         assert!(!files[0].to_string_lossy().contains(".git"));
@@ -123,7 +135,10 @@ mod tests {
         fs::write(dir.path().join("ignored.txt"), "ignored").unwrap();
 
         let paths = vec![dir.path().to_string_lossy().to_string()];
-        let files: Vec<_> = walk_paths(&paths, &[]).filter_map(|r| r.ok()).collect();
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
 
         assert!(files
             .iter()
@@ -144,6 +159,7 @@ mod tests {
         let paths = vec![dir.path().to_string_lossy().to_string()];
         let exclude = vec!["*.min.js".to_string(), "vendor/".to_string()];
         let files: Vec<_> = walk_paths(&paths, &exclude)
+            .unwrap()
             .filter_map(|r| r.ok())
             .collect();
 
@@ -161,10 +177,62 @@ mod tests {
         let paths = vec![dir.path().to_string_lossy().to_string()];
         let exclude = vec!["node_modules/".to_string()];
         let files: Vec<_> = walk_paths(&paths, &exclude)
+            .unwrap()
             .filter_map(|r| r.ok())
             .collect();
 
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("app.js"));
+    }
+
+    #[test]
+    fn test_invalid_exclude_pattern_returns_err() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+
+        let paths = vec![dir.path().to_string_lossy().to_string()];
+        let exclude = vec!["[invalid".to_string()];
+        let result = walk_paths(&paths, &exclude);
+
+        let err = result.err().expect("invalid glob pattern should error");
+        assert!(err.to_string().contains("invalid exclude pattern"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_per_entry_walk_error_does_not_abort_walk() {
+        // Regression test for issue #32: a permission error on one subdirectory
+        // must surface as an `Err` item, not silently swallow the rest of the
+        // walk. Sibling files should still be yielded.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("good.txt"), "content").unwrap();
+        let blocked_dir = dir.path().join("blocked");
+        fs::create_dir(&blocked_dir).unwrap();
+        fs::write(blocked_dir.join("inner.txt"), "content").unwrap();
+
+        let mut perms = fs::metadata(&blocked_dir).unwrap().permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&blocked_dir, perms.clone()).unwrap();
+
+        let paths = vec![dir.path().to_string_lossy().to_string()];
+        let entries: Vec<_> = walk_paths(&paths, &[]).unwrap().collect();
+
+        // Restore permissions so TempDir cleanup can remove the directory.
+        perms.set_mode(0o755);
+        fs::set_permissions(&blocked_dir, perms).unwrap();
+
+        assert!(
+            entries
+                .iter()
+                .filter_map(|r| r.as_ref().ok())
+                .any(|p| p.to_string_lossy().contains("good.txt")),
+            "sibling files must still be walked after a per-entry error: {entries:?}"
+        );
+        assert!(
+            entries.iter().any(|r| r.is_err()),
+            "permission-denied subdirectory should surface as an Err entry"
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -367,6 +367,48 @@ max_blank_lines = 1
     assert_eq!(fs::read_to_string(&file).unwrap(), "line1\n\nline2\n");
 }
 
+#[test]
+fn test_fix_then_check_idempotent_with_blank_limit_and_code_blocks() {
+    // Regression test for issue #33: max_blank_lines + fix_code_blocks must
+    // converge in a single `fini` fix pass, so an immediate `fini --check`
+    // succeeds without needing to run fix twice.
+    let dir = TempDir::new().unwrap();
+
+    let config_path = dir.path().join("fini.toml");
+    fs::write(
+        &config_path,
+        r#"
+[normalize]
+max_blank_lines = 1
+fix_code_blocks = true
+"#,
+    )
+    .unwrap();
+
+    let file = dir.path().join("sample.md");
+    fs::write(&file, "a\n\n```py\n\nb\n").unwrap();
+
+    let fix_output = fini_cmd()
+        .current_dir(dir.path())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+    assert!(fix_output.status.success());
+
+    let check_output = fini_cmd()
+        .current_dir(dir.path())
+        .arg("--check")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(
+        check_output.status.success(),
+        "check failed after fix: {}",
+        String::from_utf8_lossy(&check_output.stdout)
+    );
+}
+
 // ===========================================
 // Phase 3: Human Error Prevention Tests
 // ===========================================
@@ -535,6 +577,105 @@ detect_secrets = false
 
     // Should exit with 0 (TODO not flagged per config)
     assert!(output.status.success());
+}
+
+// ===========================================
+// Exit Codes (issue #34) & Invalid Exclude (issue #32)
+// ===========================================
+
+#[test]
+fn test_invalid_exclude_pattern_fails_closed() {
+    // Regression test for issue #32: an invalid --exclude glob must not be
+    // silently swallowed. It should abort with a non-zero exit and an stderr
+    // message, and must not process (and silently "pass") any files.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.md");
+    fs::write(&file, "hello   \n").unwrap(); // trailing whitespace, should be fixed
+
+    let output = fini_cmd()
+        .arg("--exclude")
+        .arg("[invalid")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid exclude pattern"),
+        "stderr: {stderr}"
+    );
+
+    // File must be left untouched — no silent pass-through.
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello   \n");
+}
+
+#[test]
+fn test_exit_code_0_on_success() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = fini_cmd().arg(file.to_str().unwrap()).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn test_exit_code_1_on_check_mode_problems() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello").unwrap(); // missing EOF newline
+
+    let output = fini_cmd()
+        .arg("--check")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn test_exit_code_2_on_invalid_exclude_pattern() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--exclude")
+        .arg("[invalid")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_exit_code_2_on_write_permission_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("readonly.txt");
+    fs::write(&file, "hello   \n").unwrap(); // trailing whitespace triggers a write
+
+    let mut perms = fs::metadata(&file).unwrap().permissions();
+    perms.set_mode(0o444);
+    fs::set_permissions(&file, perms.clone()).unwrap();
+
+    let output = fini_cmd().arg(file.to_str().unwrap()).output().unwrap();
+
+    // Restore permissions so TempDir cleanup can remove the file.
+    perms.set_mode(0o644);
+    fs::set_permissions(&file, perms).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error writing"), "stderr: {stderr}");
 }
 
 // ===========================================


### PR DESCRIPTION
## Summary
- `walk_paths` now fails closed on invalid `--exclude` patterns and config-level walker errors instead of silently swallowing them (#32); per-entry walk errors (e.g. permission-denied subdirectories) still surface without aborting the rest of the walk.
- `RunResult` tracks an `errors` count from walk/read/write failures. Exit code is now `0` (success), `1` (check-mode problems), `2` (runtime I/O or config errors) — applied consistently to file mode and `--stdin` (#34). Errors now print to stderr regardless of `--quiet`.
- Reordered `normalize_content`'s pipeline so `fix_code_blocks` runs before the leading-blank/blank-limit fixes, so a `fini` fix pass followed immediately by `fini --check` no longer fails when a file combines `max_blank_lines` and `fix_code_blocks` (#33).

## Test plan
- [x] `cargo test` — 205 tests passing (163 lib + 42 integration), including new regression tests for all three issues and a 96-case idempotency matrix
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #32, #33, #34

https://claude.ai/code/session_01Fzq4HC1bi7kmXmjR3NJozG