### PR TITLE
fix: address 10 architecture-review findings + comment cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,6 @@ Finally, if any problems exist, `fini:ignore` / `fini:ignore-next-line` directiv
 
 ### Testing conventions
 
-- Unit tests live inline in each module (especially extensive in `normalize/mod.rs`)
+- Unit tests live inline in each module (especially extensive in `normalize/mod.rs`), except `normalize/fix.rs`, whose transformations are covered only indirectly via `normalize_content()` tests in `mod.rs`
 - Integration tests in `tests/integration.rs` test the CLI binary end-to-end using `tempfile` for isolated directories
 - Tests are organized by feature/issue area, not a clean phase sequence — early sections carry leftover "Phase N" labels from an earlier numbering scheme (reused out of order, e.g. two unrelated "Phase 3" sections), while later sections drop phase numbers entirely in favor of issue-referenced headers (e.g. "Atomic Writes & Symlinks (issue #35)")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,4 @@ Finally, if any problems exist, `fini:ignore` / `fini:ignore-next-line` directiv
 
 - Unit tests live inline in each module (especially extensive in `normalize/mod.rs`)
 - Integration tests in `tests/integration.rs` test the CLI binary end-to-end using `tempfile` for isolated directories
-- Tests are organized by feature phase (Phase 1: core, Phase 2: config, Phase 3: detection)
+- Tests are organized by feature/issue area, not a clean phase sequence — early sections carry leftover "Phase N" labels from an earlier numbering scheme (reused out of order, e.g. two unrelated "Phase 3" sections), while later sections drop phase numbers entirely in favor of issue-referenced headers (e.g. "Atomic Writes & Symlinks (issue #35)")

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ cat file.txt | fini --stdin  # Read from stdin, output to stdout
 ### Options
 
 ```
+-c, --check             Check only (no modifications), exit 1 if problems found
+-d, --diff              Show changes in diff format
+-q, --quiet             Output only modified file names
 -v, --verbose           Show all processed files (including clean ones)
 --stdin                 Read from stdin, output to stdout
 --color                 Force colored output
@@ -71,6 +74,12 @@ cat file.txt | fini --stdin  # Read from stdin, output to stdout
 --keep-zero-width       Keep zero-width characters (default: remove)
 --keep-leading-blanks   Keep leading blank lines (default: remove)
 --fix-code-blocks       Remove code block remnants (```lang markers)
+--no-detect-todos       Skip TODO comment detection
+--no-detect-fixmes      Skip FIXME comment detection
+--no-detect-debug       Skip debug code detection
+--strict-debug          Include console.error/eprintln in debug code detection
+--no-detect-secrets     Skip secret pattern detection
+--max-line-length <N>   Maximum line length (warn if exceeded)
 --exclude <PATTERN>     Exclude files matching glob pattern (repeatable)
 --init                  Generate fini.toml configuration template
 --config <PATH>         Use specific config file

--- a/src/config/editorconfig.rs
+++ b/src/config/editorconfig.rs
@@ -30,24 +30,20 @@ pub fn parse_editorconfig(path: &Path) -> io::Result<EditorConfigSettings> {
     for line in content.lines() {
         let line = line.trim();
 
-        // Skip empty lines and comments
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
             continue;
         }
 
-        // Section header
         if line.starts_with('[') && line.ends_with(']') {
             // [*] applies to all files
             in_global_section = line == "[*]";
             continue;
         }
 
-        // Only process [*] section
         if !in_global_section {
             continue;
         }
 
-        // Parse key = value
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim().to_lowercase();
             let value = value.trim().to_lowercase();
@@ -71,8 +67,6 @@ pub fn parse_editorconfig(path: &Path) -> io::Result<EditorConfigSettings> {
 }
 
 /// Check for conflicts between .editorconfig and fini's fixed behaviors.
-///
-/// Returns a list of warning messages for conflicting settings.
 pub fn check_editorconfig_conflicts(settings: &EditorConfigSettings) -> Vec<String> {
     let mut warnings = Vec::new();
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -7,12 +7,9 @@ use std::path::{Path, PathBuf};
 
 use super::toml_schema::FiniToml;
 
-/// Error type for configuration loading
 #[derive(Debug)]
 pub enum ConfigError {
-    /// IO error reading the file
     Io(io::Error),
-    /// TOML parsing error
     Parse(toml::de::Error),
 }
 
@@ -83,7 +80,6 @@ pub fn find_config_file(start_dir: &Path) -> Option<PathBuf> {
     find_file_upward(start_dir, "fini.toml", true)
 }
 
-/// Load and parse fini.toml from the given path.
 pub fn load_config(path: &Path) -> Result<FiniToml, ConfigError> {
     let content = fs::read_to_string(path)?;
     let config: FiniToml = toml::from_str(&content)?;
@@ -122,13 +118,11 @@ mod tests {
     #[test]
     fn test_find_config_stops_at_git_root() {
         let dir = TempDir::new().unwrap();
-        // Create .git directory to mark git root
         fs::create_dir(dir.path().join(".git")).unwrap();
 
         let subdir = dir.path().join("subdir");
         fs::create_dir(&subdir).unwrap();
 
-        // No config in this tree
         let found = find_config_file(&subdir);
         assert_eq!(found, None);
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -211,4 +211,25 @@ fix_code_blocks = true
         let result = load_config(&config_path);
         assert!(matches!(result, Err(ConfigError::Parse(_))));
     }
+
+    #[test]
+    fn test_load_config_rejects_unknown_top_level_key() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("fini.toml");
+        fs::write(&config_path, "not_a_real_key = true\n").unwrap();
+
+        let result = load_config(&config_path);
+        assert!(matches!(result, Err(ConfigError::Parse(_))));
+    }
+
+    #[test]
+    fn test_load_config_rejects_unknown_normalize_key() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("fini.toml");
+        // Typo'd key must be rejected, not silently ignored.
+        fs::write(&config_path, "[normalize]\nmax_blank_line = 2\n").unwrap();
+
+        let result = load_config(&config_path);
+        assert!(matches!(result, Err(ConfigError::Parse(_))));
+    }
 }

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -96,7 +96,6 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("fini.toml");
 
-        // Create existing file
         fs::write(&config_path, "existing").unwrap();
 
         let result = generate_init_file_in(Some(dir.path()));
@@ -106,7 +105,6 @@ mod tests {
 
     #[test]
     fn test_template_is_valid_toml() {
-        // Verify the template can be parsed
         let parsed: Result<super::super::toml_schema::FiniToml, _> =
             toml::from_str(FINI_TOML_TEMPLATE);
         assert!(parsed.is_ok());

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -92,6 +92,22 @@ pub fn merge_normalize_config(
     }
 }
 
+/// Merge exclude patterns from CLI and TOML.
+///
+/// Priority: CLI > TOML > default (empty). Unlike `merge_normalize_config`,
+/// this isn't a field-by-field merge - a non-empty CLI `--exclude` list wins
+/// outright, since there's no per-pattern precedence to reconcile.
+pub fn merge_exclude_patterns(
+    cli_exclude: &[String],
+    toml_exclude: Option<&[String]>,
+) -> Vec<String> {
+    if !cli_exclude.is_empty() {
+        cli_exclude.to_vec()
+    } else {
+        toml_exclude.map(<[String]>::to_vec).unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,5 +243,33 @@ mod tests {
         assert!(config.remove_zero_width); // keep=false -> remove=true
         assert!(config.remove_leading_blanks); // keep=false -> remove=true
         assert!(config.fix_code_blocks);
+    }
+
+    #[test]
+    fn test_merge_exclude_defaults_only() {
+        let result = merge_exclude_patterns(&[], None);
+        assert_eq!(result, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_merge_exclude_toml_overrides_defaults() {
+        let toml = vec!["*.log".to_string(), "dist/".to_string()];
+        let result = merge_exclude_patterns(&[], Some(&toml));
+        assert_eq!(result, toml);
+    }
+
+    #[test]
+    fn test_merge_exclude_cli_overrides_toml() {
+        let cli = vec!["*.tmp".to_string()];
+        let toml = vec!["*.log".to_string(), "dist/".to_string()];
+        let result = merge_exclude_patterns(&cli, Some(&toml));
+        assert_eq!(result, cli);
+    }
+
+    #[test]
+    fn test_merge_exclude_cli_only() {
+        let cli = vec!["*.tmp".to_string()];
+        let result = merge_exclude_patterns(&cli, None);
+        assert_eq!(result, cli);
     }
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -17,7 +17,6 @@ pub struct CliNormalizeOptions {
     /// If Some(true), keep leading blanks (inverted in config)
     pub keep_leading_blanks: Option<bool>,
     pub fix_code_blocks: Option<bool>,
-    // Phase 3: Human Error Prevention
     /// If Some(true), skip TODO detection
     pub no_detect_todos: Option<bool>,
     /// If Some(true), skip FIXME detection
@@ -33,8 +32,6 @@ pub struct CliNormalizeOptions {
 }
 
 /// Merge configurations from CLI, TOML, and defaults.
-///
-/// Priority: CLI > TOML > defaults
 pub fn merge_normalize_config(
     cli: &CliNormalizeOptions,
     toml: Option<&NormalizeSection>,
@@ -60,7 +57,6 @@ pub fn merge_normalize_config(
             .fix_code_blocks
             .or_else(|| toml.and_then(|t| t.fix_code_blocks))
             .unwrap_or(defaults.fix_code_blocks),
-        // Phase 3: Human Error Prevention
         detect_todos: cli
             .no_detect_todos
             .map(|no| !no)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,5 +16,5 @@ mod toml_schema;
 pub use editorconfig::{check_editorconfig_conflicts, find_editorconfig, parse_editorconfig};
 pub use file::{find_config_file, find_file_upward, load_config, ConfigError};
 pub use init::{generate_init_file, FINI_TOML_TEMPLATE};
-pub use merge::{merge_normalize_config, CliNormalizeOptions};
+pub use merge::{merge_exclude_patterns, merge_normalize_config, CliNormalizeOptions};
 pub use toml_schema::{FiniToml, NormalizeSection};

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Root structure for fini.toml
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FiniToml {
     /// Normalization settings
     #[serde(default)]
@@ -16,6 +17,7 @@ pub struct FiniToml {
 
 /// `[normalize]` section in fini.toml
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NormalizeSection {
     /// Maximum consecutive blank lines (None = no limit)
     pub max_blank_lines: Option<usize>,

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FiniToml {
-    /// Normalization settings
     #[serde(default)]
     pub normalize: NormalizeSection,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,18 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
                     output::print_check_result(path, original, normalize_result, ctx);
                 } else {
                     if normalize_result.has_changes() {
-                        if let Err(e) =
-                            write_atomic(path, &normalize_result.content, *modified, *len)
-                        {
-                            eprintln!("Error writing {}: {e}", path.display());
-                            result.errors += 1;
-                            continue;
+                        if config.should_write() {
+                            if let Err(e) =
+                                write_atomic(path, &normalize_result.content, *modified, *len)
+                            {
+                                eprintln!("Error writing {}: {e}", path.display());
+                                result.errors += 1;
+                                continue;
+                            }
                         }
+                        // Counts files that changed whether or not they were
+                        // actually written — --diff previews without writing,
+                        // and print_summary picks the wording accordingly.
                         result.files_fixed += 1;
                     }
                     output::print_fix_result(path, original, normalize_result, ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ pub mod walker;
 pub use colors::{should_use_colors, Colors};
 pub use config::{
     check_editorconfig_conflicts, find_config_file, find_editorconfig, generate_init_file,
-    load_config, merge_normalize_config, parse_editorconfig, CliNormalizeOptions, ConfigError,
-    FiniToml, NormalizeSection, FINI_TOML_TEMPLATE,
+    load_config, merge_exclude_patterns, merge_normalize_config, parse_editorconfig,
+    CliNormalizeOptions, ConfigError, FiniToml, NormalizeSection, FINI_TOML_TEMPLATE,
 };
 pub use normalize::{
     mask_secret_lines, normalize_content, NormalizeConfig, NormalizeResult, Problem, ProblemKind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,21 @@ pub use walker::walk_paths;
 use rayon::prelude::*;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::SystemTime;
 
 const BINARY_CHECK_SIZE: usize = 8192;
+
+/// Files are processed in batches of this size instead of all at once: each
+/// batch is read+normalized in parallel, then applied (output/write/stats)
+/// sequentially, before the next batch starts. This bounds peak memory to
+/// roughly `CHUNK_SIZE * avg file size` (a changed file's original and
+/// normalized content are both held until it's applied) instead of holding
+/// every changed file in the run at once. 256 keeps that bound in the low
+/// tens of MB for typical source files, while staying large enough that
+/// per-chunk overhead (rayon dispatch, the sequential apply loop) is
+/// negligible next to per-file I/O cost.
+const CHUNK_SIZE: usize = 256;
 
 /// Check if content is binary by looking for null bytes in first 8192 bytes
 pub fn is_binary(content: &[u8]) -> bool {
@@ -75,74 +86,81 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
     }
     let progress = ProgressReporter::new(file_paths.len() as u64, ctx.show_progress);
 
-    // Process files in parallel (read + normalize), collect results
-    let outcomes: Vec<(PathBuf, FileOutcome)> = file_paths
-        .into_par_iter()
-        .map(|path| {
-            let outcome = process_file(&path, &config.normalize);
-            progress.inc();
-            (path, outcome)
-        })
-        .collect();
+    // Process files in fixed-size chunks: within a chunk, read+normalize run in
+    // parallel and are collected (rayon's par_iter().collect() over a slice
+    // preserves index order); then that chunk's results are applied (output +
+    // writes + stats) sequentially before the next chunk starts. This keeps
+    // walk order intact across chunk boundaries while bounding how much
+    // changed-file content is held in memory at once (see CHUNK_SIZE).
+    for chunk in file_paths.chunks(CHUNK_SIZE) {
+        let outcomes: Vec<(&Path, FileOutcome)> = chunk
+            .par_iter()
+            .map(|path| {
+                let outcome = process_file(path, &config.normalize);
+                progress.inc();
+                (path.as_path(), outcome)
+            })
+            .collect();
 
-    // Apply results sequentially (output + file writes + stats)
-    for (path, outcome) in &outcomes {
-        match outcome {
-            FileOutcome::Skipped { reason } => {
-                // Empty files are trivially "done"; only count skips that mean
-                // "this file was not inspected" (binary, non-UTF-8, symlink)
-                if *reason != "empty" {
-                    result.skipped += 1;
-                }
-                if ctx.verbose {
-                    output::print_skipped(path, reason, ctx);
-                }
-            }
-            FileOutcome::Clean { suppressed } => {
-                record_suppressed(path, suppressed, &mut result);
-                if ctx.verbose {
-                    output::print_checked(path, ctx);
-                }
-            }
-            FileOutcome::Changed {
-                original,
-                result: normalize_result,
-                modified,
-                len,
-            } => {
-                record_suppressed(path, &normalize_result.suppressed, &mut result);
-                let fullwidth_count = normalize_result
-                    .problems
-                    .iter()
-                    .filter(|p| matches!(p.kind, ProblemKind::FullWidthSpace))
-                    .count();
-                result.warnings += fullwidth_count;
-
-                if config.check_only {
-                    result.files_with_problems += 1;
-                    output::print_check_result(path, original, normalize_result, ctx);
-                } else {
-                    if normalize_result.has_changes() {
-                        if config.should_write() {
-                            if let Err(e) =
-                                write_atomic(path, &normalize_result.content, *modified, *len)
-                            {
-                                eprintln!("Error writing {}: {e}", path.display());
-                                result.errors += 1;
-                                continue;
-                            }
-                        }
-                        // Counts files that changed whether or not they were
-                        // actually written — --diff previews without writing,
-                        // and print_summary picks the wording accordingly.
-                        result.files_fixed += 1;
+        // Apply results sequentially (output + file writes + stats)
+        for (path, outcome) in &outcomes {
+            match outcome {
+                FileOutcome::Skipped { reason } => {
+                    // Empty files are trivially "done"; only count skips that mean
+                    // "this file was not inspected" (binary, non-UTF-8, symlink)
+                    if *reason != "empty" {
+                        result.skipped += 1;
                     }
-                    output::print_fix_result(path, original, normalize_result, ctx);
+                    if ctx.verbose {
+                        output::print_skipped(path, reason, ctx);
+                    }
                 }
-            }
-            FileOutcome::Error(e) => {
-                eprintln!("Error processing {}: {e}", path.display());
-                result.errors += 1;
+                FileOutcome::Clean { suppressed } => {
+                    record_suppressed(path, suppressed, &mut result);
+                    if ctx.verbose {
+                        output::print_checked(path, ctx);
+                    }
+                }
+                FileOutcome::Changed {
+                    original,
+                    result: normalize_result,
+                    modified,
+                    len,
+                } => {
+                    record_suppressed(path, &normalize_result.suppressed, &mut result);
+                    let fullwidth_count = normalize_result
+                        .problems
+                        .iter()
+                        .filter(|p| matches!(p.kind, ProblemKind::FullWidthSpace))
+                        .count();
+                    result.warnings += fullwidth_count;
+
+                    if config.check_only {
+                        result.files_with_problems += 1;
+                        output::print_check_result(path, original, normalize_result, ctx);
+                    } else {
+                        if normalize_result.has_changes() {
+                            if config.should_write() {
+                                if let Err(e) =
+                                    write_atomic(path, &normalize_result.content, *modified, *len)
+                                {
+                                    eprintln!("Error writing {}: {e}", path.display());
+                                    result.errors += 1;
+                                    continue;
+                                }
+                            }
+                            // Counts files that changed whether or not they were
+                            // actually written — --diff previews without writing,
+                            // and print_summary picks the wording accordingly.
+                            result.files_fixed += 1;
+                        }
+                        output::print_fix_result(path, original, normalize_result, ctx);
+                    }
+                }
+                FileOutcome::Error(e) => {
+                    eprintln!("Error processing {}: {e}", path.display());
+                    result.errors += 1;
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@ pub fn run(paths: &[String], config: &Config, ctx: &OutputContext) -> io::Result
             })
             .collect();
 
-        // Apply results sequentially (output + file writes + stats)
         for (path, outcome) in &outcomes {
             match outcome {
                 FileOutcome::Skipped { reason } => {
@@ -333,7 +332,6 @@ mod tests {
 
     #[test]
     fn test_binary_check_within_8192_bytes() {
-        // Null byte at position 8000 (within first 8192 bytes)
         let mut content = vec![b'a'; 8000];
         content.push(0);
         content.extend(vec![b'b'; 1000]);
@@ -342,7 +340,6 @@ mod tests {
 
     #[test]
     fn test_binary_null_after_8192_bytes_not_detected() {
-        // Null byte at position 9000 (after first 8192 bytes)
         let mut content = vec![b'a'; 9000];
         content.push(0);
         content.extend(vec![b'b'; 1000]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,17 +107,14 @@ struct Cli {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    // Handle --init command
     if cli.init {
         return handle_init();
     }
 
-    // Handle --stdin command
     if cli.stdin {
         return handle_stdin(&cli);
     }
 
-    // Load configuration
     let toml_config = match load_configuration(&cli.config, cli.quiet) {
         Ok(config) => config,
         Err(e) => {
@@ -126,15 +123,12 @@ fn main() -> ExitCode {
         }
     };
 
-    // Check for editorconfig conflicts (informational warnings)
     if !cli.quiet {
         check_editorconfig_warnings();
     }
 
-    // Build CLI options for merging
     let cli_options = build_cli_options(&cli);
 
-    // Merge configurations: CLI > TOML > defaults
     let normalize =
         merge_normalize_config(&cli_options, toml_config.as_ref().map(|c| &c.normalize));
 
@@ -171,8 +165,6 @@ fn main() -> ExitCode {
         exclude_patterns,
     };
 
-    // Determine color, verbose, and progress settings
-    // --quiet overrides --verbose
     let use_colors = should_use_colors(cli.color, cli.no_color);
     let verbose = cli.verbose && !cli.quiet;
     let show_progress = !cli.quiet && !cli.no_progress && std::io::stdout().is_terminal();
@@ -216,18 +208,15 @@ fn handle_init() -> ExitCode {
 }
 
 fn handle_stdin(cli: &Cli) -> ExitCode {
-    // Read from stdin
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {
         eprintln!("Error reading stdin: {e}");
         return ExitCode::from(2);
     }
 
-    // Build normalize config
     let cli_options = build_cli_options(cli);
     let normalize = merge_normalize_config(&cli_options, None);
 
-    // Normalize content
     let result = normalize_content(&input, &normalize);
 
     // Suppressed secrets keep an stderr audit trail in stdin mode too (issue #46)
@@ -263,7 +252,6 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    // Normal mode: output normalized content to stdout
     print!("{}", result.content);
     if let Err(e) = io::stdout().flush() {
         eprintln!("Error writing stdout: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use std::process::ExitCode;
 use clap::Parser;
 use fini::{
     check_editorconfig_conflicts, find_config_file, find_editorconfig, generate_init_file,
-    load_config, mask_secret_lines, merge_normalize_config, normalize_content, parse_editorconfig,
-    print_diff_to, run, should_use_colors, CliNormalizeOptions, Config, FiniToml, OutputContext,
-    OutputMode, ProblemKind,
+    load_config, mask_secret_lines, merge_exclude_patterns, merge_normalize_config,
+    normalize_content, parse_editorconfig, print_diff_to, run, should_use_colors,
+    CliNormalizeOptions, Config, FiniToml, OutputContext, OutputMode, ProblemKind,
 };
 
 #[derive(Parser)]
@@ -141,13 +141,11 @@ fn main() -> ExitCode {
     // A repo-local fini.toml can turn off secret detection for the very repo
     // being scanned (issue #45). Allowed, but never silent — and --quiet must
     // not hide it, since it's a security-posture downgrade the scanned target
-    // controls.
-    if toml_config
-        .as_ref()
-        .and_then(|c| c.normalize.detect_secrets)
-        == Some(false)
-        && !cli.no_detect_secrets
-    {
+    // controls. merge_normalize_config's precedence is CLI > TOML > default(true),
+    // so the merged result can only be false here if TOML set it to false and
+    // the CLI didn't ask to disable it - checking the merge output instead of
+    // re-inspecting toml_config directly.
+    if !normalize.detect_secrets && !cli.no_detect_secrets {
         eprintln!("Warning: config file disables secret detection (detect_secrets = false)");
     }
 
@@ -160,14 +158,10 @@ fn main() -> ExitCode {
     };
 
     // Merge exclude patterns: CLI --exclude takes precedence, else TOML exclude
-    let exclude_patterns = if !cli.exclude.is_empty() {
-        cli.exclude.clone()
-    } else {
-        toml_config
-            .as_ref()
-            .and_then(|c| c.exclude.clone())
-            .unwrap_or_default()
-    };
+    let exclude_patterns = merge_exclude_patterns(
+        &cli.exclude,
+        toml_config.as_ref().and_then(|c| c.exclude.as_deref()),
+    );
 
     let mask_secrets = normalize.detect_secrets;
     let config = Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,13 @@ fn main() -> ExitCode {
     }
 
     // Load configuration
-    let toml_config = load_configuration(&cli.config, cli.quiet);
+    let toml_config = match load_configuration(&cli.config, cli.quiet) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return ExitCode::from(2);
+        }
+    };
 
     // Check for editorconfig conflicts (informational warnings)
     if !cli.quiet {
@@ -273,25 +279,37 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn load_configuration(explicit_path: &Option<PathBuf>, quiet: bool) -> Option<FiniToml> {
+/// Load fini.toml, if one applies.
+///
+/// `Ok(None)` means no config file was found (explicit `--config` unset, and
+/// none discovered upward) - defaults apply silently, as documented. Once a
+/// path is resolved (explicit or discovered), that file existing but failing
+/// to load - I/O error or TOML parse error, including a `deny_unknown_fields`
+/// rejection - is a hard failure: a typo'd key must never silently fall back
+/// to defaults (see README's exit-code table).
+fn load_configuration(
+    explicit_path: &Option<PathBuf>,
+    quiet: bool,
+) -> Result<Option<FiniToml>, String> {
     let config_path = explicit_path.clone().or_else(|| {
         std::env::current_dir()
             .ok()
             .and_then(|d| find_config_file(&d))
     });
 
-    config_path.and_then(|p| match load_config(&p) {
+    let Some(p) = config_path else {
+        return Ok(None);
+    };
+
+    match load_config(&p) {
         Ok(config) => {
             if !quiet {
                 eprintln!("Using config: {}", p.display());
             }
-            Some(config)
+            Ok(Some(config))
         }
-        Err(e) => {
-            eprintln!("Warning: Failed to load {}: {}", p.display(), e);
-            None
-        }
-    })
+        Err(e) => Err(format!("{}: {e}", p.display())),
+    }
 }
 
 fn check_editorconfig_warnings() {

--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -317,7 +317,6 @@ mod tests {
 
     #[test]
     fn test_debug_print_requires_word_boundary() {
-        // "print(" must not match inside "sprint(" / "pprint(".
         assert!(detect_debug_code("sprint(x);\n", false).is_empty());
         assert!(detect_debug_code("pprint(x);\n", false).is_empty());
     }
@@ -382,7 +381,7 @@ mod tests {
     fn test_line_length_multibyte_shortcut() {
         // 6 multibyte chars = 6 char count but 18 byte length
         // byte length > limit but char count <= limit should pass
-        let line = "ああああああ\n"; // 6 chars, 18 bytes
+        let line = "ああああああ\n";
         assert!(check_line_length(line, 6).is_empty());
         assert_eq!(check_line_length(line, 5).len(), 1);
     }

--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -123,6 +123,28 @@ pub(super) fn detect_fixme_comments(content: &str) -> Vec<Problem> {
     detect_comment_markers(content, "FIXME", ProblemKind::FixmeComment)
 }
 
+/// Substring search requiring a left word boundary at the match start (the preceding
+/// byte, if any, must not be ASCII alphanumeric or `_`). Unlike `is_valid_marker`,
+/// which checks the boundary *after* a marker, call-like patterns such as
+/// `println!(` need the boundary checked *before* them, so a match inside
+/// `eprintln!(` (offset 1) doesn't count.
+fn contains_word_boundary(line: &str, pattern: &str) -> bool {
+    let bytes = line.as_bytes();
+    let plen = pattern.len();
+    if plen == 0 {
+        return false;
+    }
+    for i in 0..bytes.len().saturating_sub(plen - 1) {
+        if bytes[i..i + plen] == *pattern.as_bytes() {
+            let before = if i == 0 { None } else { Some(bytes[i - 1]) };
+            if !matches!(before, Some(b) if b.is_ascii_alphanumeric() || b == b'_') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem> {
     let extra: &[&str] = if strict_mode { STRICT_DEBUG_EXTRA } else { &[] };
 
@@ -133,7 +155,7 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
             DEBUG_PATTERNS
                 .iter()
                 .chain(extra.iter())
-                .find(|p| line.contains(*p))
+                .find(|p| contains_word_boundary(line, p))
                 .map(|pattern| Problem {
                     line: line_idx + 1,
                     kind: ProblemKind::DebugCode {
@@ -275,10 +297,17 @@ mod tests {
 
     #[test]
     fn test_debug_strict_includes_eprintln() {
-        // Note: "eprintln!(" contains "println!(" as substring, so non-strict also matches
-        // Strict mode adds the explicit "eprintln!(" pattern
-        assert_eq!(detect_debug_code("eprintln!(\"fail\");\n", false).len(), 1);
+        // "eprintln!(" contains "println!(" as a substring, but not at a word
+        // boundary (preceded by 'e'), so non-strict mode must not flag it.
+        assert!(detect_debug_code("eprintln!(\"fail\");\n", false).is_empty());
         assert_eq!(detect_debug_code("eprintln!(\"fail\");\n", true).len(), 1);
+    }
+
+    #[test]
+    fn test_debug_print_requires_word_boundary() {
+        // "print(" must not match inside "sprint(" / "pprint(".
+        assert!(detect_debug_code("sprint(x);\n", false).is_empty());
+        assert!(detect_debug_code("pprint(x);\n", false).is_empty());
     }
 
     #[test]

--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -98,29 +98,31 @@ fn is_valid_marker(line: &str, marker: &str) -> bool {
     false
 }
 
-fn detect_comment_markers(content: &str, marker: &str, kind: ProblemKind) -> Vec<Problem> {
-    content
-        .lines()
-        .enumerate()
-        .filter_map(|(line_idx, line)| {
-            if is_valid_marker(line, marker) {
-                Some(Problem {
-                    line: line_idx + 1,
-                    kind: kind.clone(),
-                })
-            } else {
-                None
-            }
-        })
-        .collect()
-}
+/// Detects TODO and FIXME markers in a single pass over `content`'s lines
+/// (each line is checked for both markers instead of scanning the file twice).
+/// Returns the two problem kinds in separate vecs, each in line order, so
+/// callers that gate TODO/FIXME detection independently can extend their
+/// combined problem list with either or both without reordering results.
+pub(super) fn detect_todo_and_fixme_comments(content: &str) -> (Vec<Problem>, Vec<Problem>) {
+    let mut todos = Vec::new();
+    let mut fixmes = Vec::new();
 
-pub(super) fn detect_todo_comments(content: &str) -> Vec<Problem> {
-    detect_comment_markers(content, "TODO", ProblemKind::TodoComment)
-}
+    for (line_idx, line) in content.lines().enumerate() {
+        if is_valid_marker(line, "TODO") {
+            todos.push(Problem {
+                line: line_idx + 1,
+                kind: ProblemKind::TodoComment,
+            });
+        }
+        if is_valid_marker(line, "FIXME") {
+            fixmes.push(Problem {
+                line: line_idx + 1,
+                kind: ProblemKind::FixmeComment,
+            });
+        }
+    }
 
-pub(super) fn detect_fixme_comments(content: &str) -> Vec<Problem> {
-    detect_comment_markers(content, "FIXME", ProblemKind::FixmeComment)
+    (todos, fixmes)
 }
 
 /// Substring search requiring a left word boundary at the match start (the preceding
@@ -251,26 +253,36 @@ mod tests {
 
     #[test]
     fn test_todo_basic() {
-        let problems = detect_todo_comments("// TODO: fix this\n");
-        assert_eq!(problems.len(), 1);
-        assert_eq!(problems[0].line, 1);
+        let (todos, _) = detect_todo_and_fixme_comments("// TODO: fix this\n");
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].line, 1);
     }
 
     #[test]
     fn test_todo_case_insensitive() {
-        assert_eq!(detect_todo_comments("// todo: fix\n").len(), 1);
-        assert_eq!(detect_todo_comments("// Todo fix\n").len(), 1);
+        assert_eq!(detect_todo_and_fixme_comments("// todo: fix\n").0.len(), 1);
+        assert_eq!(detect_todo_and_fixme_comments("// Todo fix\n").0.len(), 1);
     }
 
     #[test]
     fn test_todo_requires_word_boundary() {
-        assert!(detect_todo_comments("use todoist;\n").is_empty());
+        assert!(detect_todo_and_fixme_comments("use todoist;\n")
+            .0
+            .is_empty());
     }
 
     #[test]
     fn test_fixme_detected() {
-        let problems = detect_fixme_comments("# FIXME: broken\n");
-        assert_eq!(problems.len(), 1);
+        let (_, fixmes) = detect_todo_and_fixme_comments("# FIXME: broken\n");
+        assert_eq!(fixmes.len(), 1);
+    }
+
+    #[test]
+    fn test_todo_and_fixme_single_pass_separates_kinds() {
+        let (todos, fixmes) =
+            detect_todo_and_fixme_comments("// TODO: first\n// FIXME: second\n// TODO: third\n");
+        assert_eq!(todos.iter().map(|p| p.line).collect::<Vec<_>>(), [1, 3]);
+        assert_eq!(fixmes.iter().map(|p| p.line).collect::<Vec<_>>(), [2]);
     }
 
     #[test]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5,8 +5,7 @@ mod ignore;
 use serde::{Deserialize, Serialize};
 
 use detect::{
-    check_line_length, detect_debug_code, detect_fixme_comments, detect_secret_patterns,
-    detect_todo_comments,
+    check_line_length, detect_debug_code, detect_secret_patterns, detect_todo_and_fixme_comments,
 };
 use fix::{
     fix_fullwidth_spaces, limit_consecutive_blank_lines, normalize_eof_newline,
@@ -165,12 +164,14 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
     result = normalize_eof_newline(&result);
 
     // Detection only (no auto-fix)
-    if config.detect_todos {
-        problems.extend(detect_todo_comments(&result));
-    }
-
-    if config.detect_fixmes {
-        problems.extend(detect_fixme_comments(&result));
+    if config.detect_todos || config.detect_fixmes {
+        let (todo_problems, fixme_problems) = detect_todo_and_fixme_comments(&result);
+        if config.detect_todos {
+            problems.extend(todo_problems);
+        }
+        if config.detect_fixmes {
+            problems.extend(fixme_problems);
+        }
     }
 
     if config.detect_debug {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -13,28 +13,22 @@ use fix::{
     remove_trailing_whitespace, remove_zero_width_chars,
 };
 
-/// Configuration for normalization rules
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NormalizeConfig {
-    /// Maximum consecutive blank lines (None = no limit)
+    /// None = no limit
     pub max_blank_lines: Option<usize>,
-    /// Remove zero-width characters (default: true)
     pub remove_zero_width: bool,
-    /// Remove leading blank lines (default: true)
     pub remove_leading_blanks: bool,
-    /// Remove code block remnants (default: false)
     pub fix_code_blocks: bool,
-    /// Detect TODO comments (default: true)
     pub detect_todos: bool,
-    /// Detect FIXME comments (default: true)
     pub detect_fixmes: bool,
-    /// Detect debug code like console.log, print() (default: true)
+    /// Includes patterns like console.log, print()
     pub detect_debug: bool,
-    /// Include console.error in debug detection (default: false)
+    /// Also flags console.error, which is excluded by default
     pub strict_debug: bool,
-    /// Detect secret patterns like API keys (default: true)
+    /// Detects patterns like API keys
     pub detect_secrets: bool,
-    /// Maximum line length (None = disabled)
+    /// None = disabled
     pub max_line_length: Option<usize>,
 }
 
@@ -96,7 +90,6 @@ pub enum ProblemKind {
 }
 
 impl ProblemKind {
-    /// Returns true if this is a detection-only problem (not auto-fixed)
     pub fn is_detection_only(&self) -> bool {
         matches!(
             self,
@@ -125,7 +118,6 @@ impl ProblemKind {
     }
 }
 
-/// Normalize file content according to fini rules
 pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeResult {
     let mut result = content.to_string();
     let mut problems = vec![];
@@ -163,7 +155,6 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
     result = remove_trailing_whitespace(&result);
     result = normalize_eof_newline(&result);
 
-    // Detection only (no auto-fix)
     if config.detect_todos || config.detect_fixmes {
         let (todo_problems, fixme_problems) = detect_todo_and_fixme_comments(&result);
         if config.detect_todos {
@@ -186,8 +177,7 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
         problems.extend(check_line_length(&result, max_length));
     }
 
-    // Filter out problems suppressed by inline ignore directives, keeping
-    // the suppressed ones so they stay auditable (issue #46)
+    // Partition (not filter) so suppressed problems stay auditable (issue #46)
     let mut suppressed = vec![];
     if !problems.is_empty() {
         let ignore_map = ignore::parse_ignore_directives(&result);
@@ -219,10 +209,6 @@ pub fn mask_secret_lines(content: &str) -> String {
 mod tests {
     use super::*;
 
-    // ===========================================
-    // Suppression audit trail (issue #46)
-    // ===========================================
-
     #[test]
     fn test_ignored_problems_recorded_as_suppressed() {
         let input = "password = \"supersecret123\" # fini:ignore secret\n";
@@ -245,10 +231,6 @@ mod tests {
         assert!(result.suppressed.is_empty());
         assert_eq!(result.problems.len(), 1);
     }
-
-    // ===========================================
-    // EOF Newline Normalization
-    // ===========================================
 
     #[test]
     fn test_add_eof_newline_when_missing() {
@@ -278,10 +260,6 @@ mod tests {
         assert_eq!(result.content, "line1\nline2\n");
     }
 
-    // ===========================================
-    // Line Ending Normalization
-    // ===========================================
-
     #[test]
     fn test_crlf_to_lf() {
         let input = "line1\r\nline2\r\n";
@@ -309,10 +287,6 @@ mod tests {
         let result = normalize_content(input, &NormalizeConfig::default());
         assert_eq!(result.content, "line1\nline2\n");
     }
-
-    // ===========================================
-    // Trailing Whitespace Removal
-    // ===========================================
 
     #[test]
     fn test_remove_trailing_spaces() {
@@ -348,10 +322,6 @@ mod tests {
         let result = normalize_content(input, &NormalizeConfig::default());
         assert_eq!(result.content, "hello\nworld\n");
     }
-
-    // ===========================================
-    // Full-width Space Detection/Fix
-    // ===========================================
 
     #[test]
     fn test_detect_fullwidth_space() {
@@ -397,10 +367,6 @@ mod tests {
         );
     }
 
-    // ===========================================
-    // has_changes()
-    // ===========================================
-
     #[test]
     fn test_has_changes_when_content_modified() {
         let input = "hello";
@@ -421,10 +387,6 @@ mod tests {
         let result = normalize_content(input, &NormalizeConfig::default());
         assert!(result.has_changes());
     }
-
-    // ===========================================
-    // Leading Blank Lines Removal
-    // ===========================================
 
     #[test]
     fn test_remove_leading_blank_lines() {
@@ -471,10 +433,6 @@ mod tests {
             assert_eq!(count, 3);
         }
     }
-
-    // ===========================================
-    // Zero-width Character Removal
-    // ===========================================
 
     #[test]
     fn test_remove_zwsp() {
@@ -548,10 +506,6 @@ mod tests {
             2
         );
     }
-
-    // ===========================================
-    // Consecutive Blank Line Limit
-    // ===========================================
 
     #[test]
     fn test_limit_blank_lines_to_2() {
@@ -642,10 +596,6 @@ mod tests {
         );
     }
 
-    // ===========================================
-    // Code Block Remnant Removal
-    // ===========================================
-
     #[test]
     fn test_remove_code_fence_opening() {
         let config = NormalizeConfig {
@@ -728,10 +678,6 @@ mod tests {
         }
     }
 
-    // ===========================================
-    // Edge Cases: Leading Blank Lines
-    // ===========================================
-
     #[test]
     fn test_file_with_only_blank_lines() {
         let input = "\n\n\n";
@@ -753,10 +699,6 @@ mod tests {
         assert_eq!(result.content, "");
         assert!(!result.has_changes());
     }
-
-    // ===========================================
-    // Edge Cases: Zero-width Characters
-    // ===========================================
 
     #[test]
     fn test_zero_width_at_start_of_line() {
@@ -794,10 +736,6 @@ mod tests {
         );
     }
 
-    // ===========================================
-    // Edge Cases: Consecutive Blank Lines
-    // ===========================================
-
     #[test]
     fn test_blank_lines_at_end_of_file() {
         let config = NormalizeConfig {
@@ -832,10 +770,6 @@ mod tests {
         let result = normalize_content(input, &config);
         assert_eq!(result.content, "a\n\nb\n");
     }
-
-    // ===========================================
-    // Edge Cases: Code Block Remnants
-    // ===========================================
 
     #[test]
     fn test_indented_code_fence() {
@@ -880,10 +814,6 @@ mod tests {
         let result = normalize_content(input, &config);
         assert_eq!(result.content, "````rust\ncode\n");
     }
-
-    // ===========================================
-    // Edge Cases: Combined Features
-    // ===========================================
 
     #[test]
     fn test_all_features_combined() {
@@ -978,10 +908,6 @@ mod tests {
         assert_eq!(result.content, "code\n");
     }
 
-    // ===========================================
-    // Long Line Detection
-    // ===========================================
-
     #[test]
     fn test_detect_line_over_default_limit() {
         let config = NormalizeConfig {
@@ -1064,10 +990,6 @@ mod tests {
         assert!(problem.is_none());
     }
 
-    // ===========================================
-    // TODO/FIXME Detection
-    // ===========================================
-
     #[test]
     fn test_detect_todo_in_single_line_comment() {
         let input = "// TODO: fix this later\n";
@@ -1147,10 +1069,6 @@ mod tests {
         assert!(problem.is_none());
     }
 
-    // ===========================================
-    // Debug Code Detection
-    // ===========================================
-
     #[test]
     fn test_detect_console_log() {
         let input = "console.log('debug');\n";
@@ -1206,10 +1124,6 @@ mod tests {
         assert!(problem.is_none());
     }
 
-    // ===========================================
-    // Secret Pattern Detection
-    // ===========================================
-
     #[test]
     fn test_detect_api_key_pattern() {
         let input = "const API_KEY = \"sk_live_abcd1234\";\n";
@@ -1246,8 +1160,6 @@ mod tests {
             .find(|p| matches!(p.kind, ProblemKind::SecretPattern { .. }));
         assert!(problem.is_none());
     }
-
-    // ── Inline ignore directives ──
 
     #[test]
     fn test_ignore_inline_suppresses_todo() {

--- a/src/output.rs
+++ b/src/output.rs
@@ -132,7 +132,6 @@ pub fn print_check_result(
         }
     }
 
-    // Problems from normalization
     for problem in &result.problems {
         match &problem.kind {
             ProblemKind::FullWidthSpace => {
@@ -188,7 +187,6 @@ pub fn print_fix_result(
             print_diff(&path.display().to_string(), &orig, &new);
         }
         OutputMode::Normal => {
-            // Print warnings for full-width spaces
             for problem in result
                 .problems
                 .iter()

--- a/src/output.rs
+++ b/src/output.rs
@@ -92,42 +92,50 @@ pub fn print_check_result(
     }
 
     if ctx.mode == OutputMode::Diff {
-        // Mirrors print_fix_result's Diff branch: a diff, not the textual
-        // problem list, masked the same way (issue #44's contract applies
-        // to every diff path, not just fix mode).
-        let (orig, new) = masked_pair(original, &result.content, ctx.mask_secrets);
-        print_diff(&path.display().to_string(), &orig, &new);
-        return;
-    }
-
-    println!(
-        "{}Error:{} {}",
-        ctx.colors.error,
-        ctx.colors.reset(),
-        path.display()
-    );
-
-    if result.has_changes() {
-        let orig_trimmed = original.trim_end_matches(['\n', '\r']);
-        let orig_trailing_newlines = original[orig_trimmed.len()..]
-            .chars()
-            .filter(|&c| c == '\n')
-            .count();
-        let result_trimmed = result.content.trim_end_matches(['\n', '\r']);
-        let result_trailing_newlines = result.content[result_trimmed.len()..]
-            .chars()
-            .filter(|&c| c == '\n')
-            .count();
-
-        if orig_trailing_newlines == 0 && result_trailing_newlines > 0 {
-            println!("  - missing EOF newline");
-        } else if orig_trailing_newlines > 1 && result_trailing_newlines < orig_trailing_newlines {
-            println!("  - extra trailing newline(s) removed");
+        // Mirrors print_fix_result's Diff branch: masked the same way
+        // (issue #44's contract applies to every diff path, not just fix
+        // mode). Unlike print_fix_result, we don't return early: detection-
+        // only problems (TODO/FIXME/debug/secret/long-line) never change
+        // result.content, so there's no diff to show them in — they're only
+        // visible via the problem list below, which must still run. When
+        // there IS a content diff, skip the empty `---`/`+++` header instead
+        // of printing a diff with no body.
+        if result.has_changes() {
+            let (orig, new) = masked_pair(original, &result.content, ctx.mask_secrets);
+            print_diff(&path.display().to_string(), &orig, &new);
         }
+    } else {
+        println!(
+            "{}Error:{} {}",
+            ctx.colors.error,
+            ctx.colors.reset(),
+            path.display()
+        );
 
-        for (i, orig_line) in original.lines().enumerate() {
-            if orig_line.len() != orig_line.trim_end().len() {
-                println!("  - trailing whitespace at line {}", i + 1);
+        if result.has_changes() {
+            let orig_trimmed = original.trim_end_matches(['\n', '\r']);
+            let orig_trailing_newlines = original[orig_trimmed.len()..]
+                .chars()
+                .filter(|&c| c == '\n')
+                .count();
+            let result_trimmed = result.content.trim_end_matches(['\n', '\r']);
+            let result_trailing_newlines = result.content[result_trimmed.len()..]
+                .chars()
+                .filter(|&c| c == '\n')
+                .count();
+
+            if orig_trailing_newlines == 0 && result_trailing_newlines > 0 {
+                println!("  - missing EOF newline");
+            } else if orig_trailing_newlines > 1
+                && result_trailing_newlines < orig_trailing_newlines
+            {
+                println!("  - extra trailing newline(s) removed");
+            }
+
+            for (i, orig_line) in original.lines().enumerate() {
+                if orig_line.len() != orig_line.trim_end().len() {
+                    println!("  - trailing whitespace at line {}", i + 1);
+                }
             }
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -19,6 +19,17 @@ pub struct Config {
     pub exclude_patterns: Vec<String>,
 }
 
+impl Config {
+    /// Whether normalized content should actually be written to disk.
+    /// Check mode never writes (`check_only` also gates the exit-code check
+    /// in main.rs and keeps that meaning); `--diff` alone is a preview per
+    /// the README ("Preview changes") and must not write either.
+    #[must_use]
+    pub fn should_write(&self) -> bool {
+        !self.check_only && self.output_mode != OutputMode::Diff
+    }
+}
+
 pub struct OutputContext {
     pub mode: OutputMode,
     pub colors: Colors,
@@ -77,6 +88,15 @@ pub fn print_check_result(
 ) {
     if ctx.mode == OutputMode::Quiet {
         println!("{}", path.display());
+        return;
+    }
+
+    if ctx.mode == OutputMode::Diff {
+        // Mirrors print_fix_result's Diff branch: a diff, not the textual
+        // problem list, masked the same way (issue #44's contract applies
+        // to every diff path, not just fix mode).
+        let (orig, new) = masked_pair(original, &result.content, ctx.mask_secrets);
+        print_diff(&path.display().to_string(), &orig, &new);
         return;
     }
 
@@ -288,10 +308,18 @@ pub fn print_summary(result: &RunResult, config: &Config, ctx: &OutputContext) {
         }
     } else {
         if result.files_fixed > 0 {
+            // Bare --diff previews changes without writing them (README:
+            // "Preview changes"), so the count is what *would* be fixed.
+            let label = if config.should_write() {
+                "files fixed"
+            } else {
+                "files would be fixed"
+            };
             parts.push(format!(
-                "{}{} files fixed{}",
+                "{}{} {}{}",
                 ctx.colors.success,
                 result.files_fixed,
+                label,
                 ctx.colors.reset()
             ));
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -88,11 +88,24 @@ pub fn print_check_result(
     );
 
     if result.has_changes() {
-        if !original.ends_with('\n') && result.content.ends_with('\n') {
+        let orig_trimmed = original.trim_end_matches(['\n', '\r']);
+        let orig_trailing_newlines = original[orig_trimmed.len()..]
+            .chars()
+            .filter(|&c| c == '\n')
+            .count();
+        let result_trimmed = result.content.trim_end_matches(['\n', '\r']);
+        let result_trailing_newlines = result.content[result_trimmed.len()..]
+            .chars()
+            .filter(|&c| c == '\n')
+            .count();
+
+        if orig_trailing_newlines == 0 && result_trailing_newlines > 0 {
             println!("  - missing EOF newline");
+        } else if orig_trailing_newlines > 1 && result_trailing_newlines < orig_trailing_newlines {
+            println!("  - extra trailing newline(s) removed");
         }
 
-        for (i, (orig_line, _)) in original.lines().zip(result.content.lines()).enumerate() {
+        for (i, orig_line) in original.lines().enumerate() {
             if orig_line.len() != orig_line.trim_end().len() {
                 println!("  - trailing whitespace at line {}", i + 1);
             }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -201,9 +201,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_per_entry_walk_error_does_not_abort_walk() {
-        // Regression test for issue #32: a permission error on one subdirectory
-        // must surface as an `Err` item, not silently swallow the rest of the
-        // walk. Sibling files should still be yielded.
+        // Regression test for issue #32.
         use std::os::unix::fs::PermissionsExt;
 
         let dir = TempDir::new().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -658,6 +658,27 @@ fn test_exit_code_1_on_check_mode_problems() {
 }
 
 #[test]
+fn test_check_mode_reports_extra_trailing_newlines_with_crlf() {
+    // Regression test: trailing-newline counting must not undercount CRLF
+    // line endings (each "\r\n" is one newline, not zero).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "X\r\n\r\n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--check")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("extra trailing newline(s) removed"),
+        "expected extra trailing newline(s) removed message, got: {stdout}"
+    );
+}
+
+#[test]
 fn test_exit_code_2_on_invalid_exclude_pattern() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1015,6 +1015,34 @@ fn test_diff_masks_secret_lines() {
 }
 
 #[test]
+fn test_check_diff_shows_detection_only_problems() {
+    // Regression test: a file whose only problems are detection-only
+    // (secret pattern here; same applies to TODO/FIXME/debug/long-line)
+    // never changes result.content vs original, so `--check --diff` used to
+    // print an empty `---`/`+++` diff and return before ever reaching the
+    // problem list, silently dropping the secret hint (exit 1 with no
+    // indication why). The problem list must still print even when there's
+    // no content diff to show.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("secret.py");
+    fs::write(&file, "password = \"supersecret123\"\n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--check")
+        .arg("--diff")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("potential secret"),
+        "secret hint missing from --check --diff output: {stdout}"
+    );
+}
+
+#[test]
 fn test_stdin_check_diff_goes_to_stderr() {
     // Regression test for issue #38: --stdin --check --diff must keep stdout
     // clean (its contract is "normalized content only") and put the diff on

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -204,6 +205,62 @@ fn test_multiple_files() {
 
     assert_eq!(fs::read_to_string(&file1).unwrap(), "hello\n");
     assert_eq!(fs::read_to_string(&file2).unwrap(), "world\n");
+}
+
+#[test]
+fn test_many_files_preserve_order_and_identity_across_chunks() {
+    // Regression test for the chunked-processing refactor in `run()`: files are
+    // now processed in fixed-size batches (CHUNK_SIZE in src/lib.rs) instead of
+    // all at once. Two things a batching bug could break:
+    //   1. pairing — one file's fix landing in another file (chunk-boundary mixup)
+    //   2. ordering — output no longer matches walk order across chunk boundaries
+    // Use more files than CHUNK_SIZE so the run spans multiple chunks. Passing
+    // them as explicit CLI args (rather than walking a directory) pins the input
+    // order to something this test controls and can assert against — directory
+    // walk order is filesystem-dependent and not something a test should assume.
+    let dir = TempDir::new().unwrap();
+    let file_count = 600;
+    let mut cmd = fini_cmd();
+    cmd.arg("--quiet");
+    for i in 0..file_count {
+        let path = dir.path().join(format!("file{i:04}.txt"));
+        // Missing EOF newline (needs a fix) so every file is printed and written.
+        fs::write(&path, format!("content-{i}")).unwrap();
+        cmd.arg(&path);
+    }
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    for i in 0..file_count {
+        let content = fs::read_to_string(dir.path().join(format!("file{i:04}.txt"))).unwrap();
+        assert_eq!(
+            content,
+            format!("content-{i}\n"),
+            "mismatch for file{i:04}.txt"
+        );
+    }
+
+    // --quiet prints exactly one line (the path) per fixed file, in apply order.
+    // Extract each file's index from its printed path and confirm the sequence
+    // is exactly 0..file_count — not just "no crash", but "order preserved".
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let indices: Vec<usize> = stdout
+        .lines()
+        .map(|line| {
+            let name = Path::new(line.trim())
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap();
+            name.strip_prefix("file").unwrap().parse().unwrap()
+        })
+        .collect();
+    let expected: Vec<usize> = (0..file_count).collect();
+    assert_eq!(
+        indices, expected,
+        "output order must match input walk order"
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -998,6 +998,43 @@ fn test_stdin_check_diff_goes_to_stderr() {
     );
 }
 
+#[test]
+fn test_diff_mode_previews_without_writing() {
+    // Regression test: README documents `fini --diff .` as "Preview changes",
+    // but bare --diff used to write the normalized content to disk anyway
+    // (only --check --diff skipped the write). --diff alone must be a
+    // read-only preview: print a diff, leave the file untouched, exit 0.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello").unwrap(); // missing EOF newline
+
+    let before_content = fs::read(&file).unwrap();
+    let before_mtime = fs::metadata(&file).unwrap().modified().unwrap();
+
+    let output = fini_cmd()
+        .arg("--diff")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("---"), "missing diff header: {stdout}");
+    assert!(stdout.contains("+++"), "missing diff header: {stdout}");
+
+    let after_content = fs::read(&file).unwrap();
+    let after_mtime = fs::metadata(&file).unwrap().modified().unwrap();
+    assert_eq!(
+        before_content, after_content,
+        "--diff must not modify file content"
+    );
+    assert_eq!(
+        before_mtime, after_mtime,
+        "--diff must not touch the file (mtime changed)"
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
 // ===========================================
 // Secret Detection Trust Boundary & Audit Trail (issues #45, #46)
 // ===========================================

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -429,6 +429,71 @@ fix_code_blocks = true
     );
 }
 
+#[test]
+fn test_invalid_config_toml_exits_2() {
+    // A syntactically invalid fini.toml must be a hard failure (exit 2), not
+    // a warning that silently falls back to defaults.
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("fini.toml");
+    fs::write(&config_path, "invalid toml {{{\n").unwrap();
+
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = fini_cmd()
+        .current_dir(dir.path())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error"), "stderr: {stderr}");
+}
+
+#[test]
+fn test_config_unknown_key_exits_2() {
+    // A typo'd key (e.g. max_blank_line instead of max_blank_lines) must be
+    // rejected outright, not silently ignored while the rest of the config
+    // (or defaults) apply.
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("fini.toml");
+    fs::write(&config_path, "[normalize]\nmax_blank_line = 2\n").unwrap();
+
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = fini_cmd()
+        .current_dir(dir.path())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error"), "stderr: {stderr}");
+}
+
+#[test]
+fn test_explicit_config_path_missing_exits_2() {
+    // An explicit --config pointing at a nonexistent file is also a hard
+    // failure, not a silent fallback to defaults.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--config")
+        .arg(dir.path().join("does-not-exist.toml").to_str().unwrap())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error"), "stderr: {stderr}");
+}
+
 // ===========================================
 // Phase 3: Human Error Prevention Tests
 // ===========================================


### PR DESCRIPTION
## Summary

Fixes all 10 findings from a Fable-led architecture audit of the codebase (wasteful processing, doc/code inconsistencies, and one hardening gap), plus a comment-cleanup pass. Ordered and sequenced per Fable's recommendation to minimize file-overlap rework; each commit was implemented by a sonnet sub-agent and reviewed by a fable sub-agent (low effort) before landing.

- **fix(output)**: stop under-reporting problems in `--check` mode (zip truncation + CRLF trailing-newline undercount)
- **fix(detect)**: stop flagging `eprintln!` as debug code in non-strict mode (substring false-positive + dead strict-mode pattern)
- **perf(detect)**: fuse TODO/FIXME detection into a single line pass
- **fix(config)**: reject unknown TOML keys (`deny_unknown_fields`) and hard-fail (exit 2) on config parse errors, instead of silently discarding the config
- **refactor(config)**: route exclude-pattern and secret-warning precedence through the single tested merge path instead of ad hoc main.rs logic
- **fix(cli)**: make `--diff` a true no-write preview, matching README's documented behavior; `--check --diff` now actually prints a (masked) diff
- **perf(lib)**: chunk `run()` to bound peak memory instead of buffering every changed file at once
- **docs(readme)**: document all CLI flags in the Options table (9 were missing)
- **docs(claude)**: correct two false claims about test organization and inline-test coverage
- **refactor(comments)**: remove comments that just restate what the code already shows, across `src/`

## Test plan
- [x] `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` pass after every commit
- [x] Each commit reviewed by a fable sub-agent (low effort) before landing; findings addressed (e.g. a CRLF edge case caught in the output.rs fix)
- [x] New regression tests added: CRLF trailing-newline collapse, eprintln! word-boundary, `--diff` no-write + mtime/content unchanged, config hard-fail on invalid/unknown-key TOML, 600-file chunk-ordering integrity

https://claude.ai/code/session_01BSZTSHsBzrPiZP8fPpHNsu