### PR TITLE
fix(config): move exclude out of [normalize] in --init template

### DIFF
--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -17,6 +17,15 @@ pub const FINI_TOML_TEMPLATE: &str = r#"# fini.toml - Configuration for fini fil
 # These behaviors are always enabled. The settings below control
 # optional features - uncomment and modify as needed.
 
+# Exclude files matching these patterns (gitignore-style globs).
+# CLI --exclude flags override this list.
+# exclude = [
+#     "vendor/",
+#     "node_modules/",
+#     "*.min.js",
+#     "*.min.css",
+# ]
+
 [normalize]
 # Maximum consecutive blank lines allowed.
 # Set to 0 to remove all blank lines, or comment out for no limit.
@@ -36,14 +45,28 @@ pub const FINI_TOML_TEMPLATE: &str = r#"# fini.toml - Configuration for fini fil
 # Default: false
 # fix_code_blocks = false
 
-# Exclude files matching these patterns (gitignore-style globs).
-# CLI --exclude flags override this list.
-# exclude = [
-#     "vendor/",
-#     "node_modules/",
-#     "*.min.js",
-#     "*.min.css",
-# ]
+# Detect TODO comments.
+# Default: true
+# detect_todos = true
+
+# Detect FIXME comments.
+# Default: true
+# detect_fixmes = true
+
+# Detect debug code (console.log, print, dbg!, etc.).
+# Default: true
+# detect_debug = true
+
+# Include console.error/eprintln in debug code detection.
+# Default: false
+# strict_debug = false
+
+# Detect secret patterns (API keys, tokens, etc.).
+# Default: true
+# detect_secrets = true
+
+# Maximum line length (warn if exceeded). Comment out to disable.
+# max_line_length = 120
 "#;
 
 /// Generate fini.toml in the specified directory (or current directory if None).
@@ -108,5 +131,44 @@ mod tests {
         let parsed: Result<super::super::toml_schema::FiniToml, _> =
             toml::from_str(FINI_TOML_TEMPLATE);
         assert!(parsed.is_ok());
+    }
+
+    /// Uncommenting every `# key = value` line in the generated template must still
+    /// produce valid, schema-conformant TOML (regression test for issue #82, where
+    /// `exclude` was placed inside `[normalize]` and uncommenting it broke
+    /// `deny_unknown_fields`).
+    #[test]
+    fn test_template_fully_uncommented_is_valid_toml() {
+        let mut in_array = false;
+        let uncommented: String = FINI_TOML_TEMPLATE
+            .lines()
+            .map(|line| {
+                let trimmed = line.trim_start();
+                let is_key_line = trimmed
+                    .strip_prefix("# ")
+                    .is_some_and(|rest| rest.contains('='));
+                let is_array_elem_line = in_array && trimmed.strip_prefix("# ").is_some();
+
+                if is_key_line || is_array_elem_line {
+                    let uncommented_line = line.replacen("# ", "", 1);
+                    if is_key_line && uncommented_line.trim_end().ends_with('[') {
+                        in_array = true;
+                    } else if in_array && uncommented_line.trim_end().ends_with(']') {
+                        in_array = false;
+                    }
+                    return uncommented_line;
+                }
+                line.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let parsed: Result<super::super::toml_schema::FiniToml, _> = toml::from_str(&uncommented);
+        assert!(
+            parsed.is_ok(),
+            "uncommented template failed to parse: {:?}\n---\n{}",
+            parsed.err(),
+            uncommented
+        );
     }
 }

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -144,9 +144,12 @@ mod tests {
             .lines()
             .map(|line| {
                 let trimmed = line.trim_start();
-                let is_key_line = trimmed
-                    .strip_prefix("# ")
-                    .is_some_and(|rest| rest.contains('='));
+                let is_key_line = trimmed.strip_prefix("# ").is_some_and(|rest| {
+                    rest.split_once(" = ").is_some_and(|(key, _)| {
+                        !key.is_empty()
+                            && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    })
+                });
                 let is_array_elem_line = in_array && trimmed.strip_prefix("# ").is_some();
 
                 if is_key_line || is_array_elem_line {
@@ -164,11 +167,23 @@ mod tests {
             .join("\n");
 
         let parsed: Result<super::super::toml_schema::FiniToml, _> = toml::from_str(&uncommented);
-        assert!(
-            parsed.is_ok(),
-            "uncommented template failed to parse: {:?}\n---\n{}",
-            parsed.err(),
-            uncommented
-        );
+        let config = parsed.unwrap_or_else(|err| {
+            panic!("uncommented template failed to parse: {err:?}\n---\n{uncommented}")
+        });
+
+        // Assert every field actually landed, so a key silently missed by the
+        // uncomment logic above (or dropped from the template) fails loudly
+        // instead of passing on an incompletely-uncommented template.
+        assert_eq!(config.exclude.as_deref().map(<[String]>::len), Some(4));
+        assert_eq!(config.normalize.max_blank_lines, Some(2));
+        assert_eq!(config.normalize.remove_zero_width, Some(true));
+        assert_eq!(config.normalize.remove_leading_blanks, Some(true));
+        assert_eq!(config.normalize.fix_code_blocks, Some(false));
+        assert_eq!(config.normalize.detect_todos, Some(true));
+        assert_eq!(config.normalize.detect_fixmes, Some(true));
+        assert_eq!(config.normalize.detect_debug, Some(true));
+        assert_eq!(config.normalize.strict_debug, Some(false));
+        assert_eq!(config.normalize.detect_secrets, Some(true));
+        assert_eq!(config.normalize.max_line_length, Some(120));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #82: `fini --init` generated `exclude = [...]` (commented) inside `[normalize]`, but `exclude` is a top-level `FiniToml` field and `NormalizeSection` has `#[serde(deny_unknown_fields)]`. Uncommenting it per the template's own instructions caused a TOML parse error (exit 2).
- Moved the `exclude` example above the `[normalize]` header, matching both `toml_schema.rs` and the README's example.
- Added commented examples for the remaining `NormalizeSection` fields that were missing from the template: `detect_todos`, `detect_fixmes`, `detect_debug`, `strict_debug`, `detect_secrets`, `max_line_length`.
- Added a regression test (`test_template_fully_uncommented_is_valid_toml`) that uncomments every `# key = value` line in the generated template — including the multi-line `exclude` array — and asserts the result still parses against `FiniToml`, pinning template/schema consistency permanently.

## Test plan
- [x] `cargo test` (178 lib tests incl. new regression test, 58 integration tests) — all passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manually verified: `fini --init`, uncomment `exclude` block, `fini --check .` no longer errors

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd