### PR TITLE
fix(stdin): print detection-only problems on --stdin --check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ pub use config::{
 pub use normalize::{
     mask_secret_lines, normalize_content, NormalizeConfig, NormalizeResult, Problem, ProblemKind,
 };
-pub use output::{print_diff, print_diff_to, Config, OutputContext, OutputMode, RunResult};
+pub use output::{
+    print_diff, print_diff_to, print_problems_to, Config, OutputContext, OutputMode, RunResult,
+};
 pub use progress::ProgressReporter;
 pub use walker::walk_paths;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ pub use normalize::{
     mask_secret_lines, normalize_content, NormalizeConfig, NormalizeResult, Problem, ProblemKind,
 };
 pub use output::{
-    print_diff, print_diff_to, print_problems_to, Config, OutputContext, OutputMode, RunResult,
+    print_change_summary_to, print_diff, print_diff_to, print_problems_to, Config, OutputContext,
+    OutputMode, RunResult,
 };
 pub use progress::ProgressReporter;
 pub use walker::walk_paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,9 @@ use clap::Parser;
 use fini::{
     check_editorconfig_conflicts, find_config_file, find_editorconfig, generate_init_file,
     load_config, mask_secret_lines, merge_exclude_patterns, merge_normalize_config,
-    normalize_content, parse_editorconfig, print_diff_to, run, should_use_colors,
-    CliNormalizeOptions, Config, FiniToml, OutputContext, OutputMode, ProblemKind,
+    normalize_content, parse_editorconfig, print_diff_to, print_problems_to, run,
+    should_use_colors, CliNormalizeOptions, Config, FiniToml, OutputContext, OutputMode,
+    ProblemKind,
 };
 
 #[derive(Parser)]
@@ -231,10 +232,14 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
 
     if cli.check {
         if result.has_changes() || result.has_detection_problems() {
-            if cli.diff {
-                // Diff goes to stderr so stdout keeps its "normalized content
-                // only" contract (issue #38), masked like every other diff
-                // path (issue #44)
+            // Diagnostics go to stderr so stdout keeps its "normalized
+            // content only" contract (issue #38). Best-effort: a closed
+            // stderr must not mask the check failure exit code.
+            let mut stderr = io::stderr().lock();
+            if cli.diff && result.has_changes() {
+                // Matches file-mode's guard (print_check_result): skip the
+                // diff header entirely when there's no content change, since
+                // detection-only problems never touch result.content.
                 let (orig, new): (Cow<str>, Cow<str>) = if normalize.detect_secrets {
                     (
                         Cow::Owned(mask_secret_lines(&input)),
@@ -243,10 +248,9 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
                 } else {
                     (Cow::Borrowed(&input), Cow::Borrowed(&result.content))
                 };
-                // Best-effort diagnostics: a closed stderr must not mask the
-                // check failure exit code
-                let _ = print_diff_to(&mut io::stderr().lock(), "stdin", &orig, &new);
+                let _ = print_diff_to(&mut stderr, "stdin", &orig, &new);
             }
+            let _ = print_problems_to(&mut stderr, &result.problems);
             return ExitCode::from(1);
         }
         return ExitCode::SUCCESS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use clap::Parser;
 use fini::{
     check_editorconfig_conflicts, find_config_file, find_editorconfig, generate_init_file,
     load_config, mask_secret_lines, merge_exclude_patterns, merge_normalize_config,
-    normalize_content, parse_editorconfig, print_diff_to, print_problems_to, run,
-    should_use_colors, CliNormalizeOptions, Config, FiniToml, OutputContext, OutputMode,
-    ProblemKind,
+    normalize_content, parse_editorconfig, print_change_summary_to, print_diff_to,
+    print_problems_to, run, should_use_colors, CliNormalizeOptions, Config, FiniToml,
+    OutputContext, OutputMode, ProblemKind,
 };
 
 #[derive(Parser)]
@@ -232,25 +232,35 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
 
     if cli.check {
         if result.has_changes() || result.has_detection_problems() {
-            // Diagnostics go to stderr so stdout keeps its "normalized
-            // content only" contract (issue #38). Best-effort: a closed
-            // stderr must not mask the check failure exit code.
-            let mut stderr = io::stderr().lock();
-            if cli.diff && result.has_changes() {
-                // Matches file-mode's guard (print_check_result): skip the
-                // diff header entirely when there's no content change, since
-                // detection-only problems never touch result.content.
-                let (orig, new): (Cow<str>, Cow<str>) = if normalize.detect_secrets {
-                    (
-                        Cow::Owned(mask_secret_lines(&input)),
-                        Cow::Owned(mask_secret_lines(&result.content)),
-                    )
-                } else {
-                    (Cow::Borrowed(&input), Cow::Borrowed(&result.content))
-                };
-                let _ = print_diff_to(&mut stderr, "stdin", &orig, &new);
+            if !cli.quiet {
+                // Diagnostics go to stderr so stdout keeps its "normalized
+                // content only" contract (issue #38). Best-effort: a closed
+                // stderr must not mask the check failure exit code.
+                let mut stderr = io::stderr().lock();
+                if cli.diff {
+                    let (orig, new): (Cow<str>, Cow<str>) = if normalize.detect_secrets {
+                        (
+                            Cow::Owned(mask_secret_lines(&input)),
+                            Cow::Owned(mask_secret_lines(&result.content)),
+                        )
+                    } else {
+                        (Cow::Borrowed(&input), Cow::Borrowed(&result.content))
+                    };
+                    // Matches file-mode's guard (print_check_result): skip
+                    // the diff header when there's nothing to show a diff
+                    // of - either no content change, or masking collapsed
+                    // the only change (a secret line) to identical text.
+                    if orig != new {
+                        let _ = print_diff_to(&mut stderr, "stdin", &orig, &new);
+                    }
+                } else if result.has_changes() {
+                    // Detection-only problems never touch result.content, so
+                    // there's nothing to summarize for them here - they're
+                    // covered by print_problems_to below regardless.
+                    let _ = print_change_summary_to(&mut stderr, &input, &result.content);
+                }
+                let _ = print_problems_to(&mut stderr, &result.problems);
             }
-            let _ = print_problems_to(&mut stderr, &result.problems);
             return ExitCode::from(1);
         }
         return ExitCode::SUCCESS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,18 +246,24 @@ fn handle_stdin(cli: &Cli) -> ExitCode {
                     } else {
                         (Cow::Borrowed(&input), Cow::Borrowed(&result.content))
                     };
-                    // Matches file-mode's guard (print_check_result): skip
-                    // the diff header when there's nothing to show a diff
-                    // of - either no content change, or masking collapsed
-                    // the only change (a secret line) to identical text.
+                    // Skip the diff header when there's nothing to show a
+                    // diff of - either no content change, or masking
+                    // collapsed the only change (a secret line) to identical
+                    // text. Stricter than file-mode's print_check_result,
+                    // which only guards on the unmasked has_changes().
                     if orig != new {
                         let _ = print_diff_to(&mut stderr, "stdin", &orig, &new);
                     }
-                } else if result.has_changes() {
-                    // Detection-only problems never touch result.content, so
-                    // there's nothing to summarize for them here - they're
-                    // covered by print_problems_to below regardless.
-                    let _ = print_change_summary_to(&mut stderr, &input, &result.content);
+                } else {
+                    // Unconditional header (mirrors file-mode's "Error: <path>"
+                    // in print_check_result): some fix-only transforms - e.g.
+                    // CRLF normalization - fire neither a Problem entry nor a
+                    // print_change_summary_to bullet, so without this stderr
+                    // could otherwise stay empty despite the exit 1.
+                    let _ = writeln!(stderr, "Error: stdin");
+                    if result.has_changes() {
+                        let _ = print_change_summary_to(&mut stderr, &input, &result.content);
+                    }
                 }
                 let _ = print_problems_to(&mut stderr, &result.problems);
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,5 @@
 use crate::colors::Colors;
-use crate::normalize::{mask_secret_lines, NormalizeConfig, NormalizeResult, ProblemKind};
+use crate::normalize::{mask_secret_lines, NormalizeConfig, NormalizeResult, Problem, ProblemKind};
 use similar::{ChangeTag, TextDiff};
 use std::borrow::Cow;
 use std::io::{self, Write};
@@ -140,46 +140,63 @@ pub fn print_check_result(
         }
     }
 
-    for problem in &result.problems {
+    let stdout = io::stdout();
+    // Panicking on a failed stdout write matches println!'s historical behavior
+    print_problems_to(&mut stdout.lock(), &result.problems).expect("failed to write to stdout");
+}
+
+/// Prints the per-problem diagnostic list (e.g. "- TODO comment at line 3").
+/// Shared by file-mode check output (to stdout) and `--stdin --check`
+/// diagnostics (to stderr, since stdin's stdout is reserved for normalized
+/// content only - issue #38).
+pub fn print_problems_to<W: Write>(w: &mut W, problems: &[Problem]) -> io::Result<()> {
+    for problem in problems {
         match &problem.kind {
             ProblemKind::FullWidthSpace => {
-                println!("  - full-width space at line {}", problem.line);
+                writeln!(w, "  - full-width space at line {}", problem.line)?;
             }
             ProblemKind::LeadingBlankLines { count } => {
-                println!("  - {} leading blank line(s)", count);
+                writeln!(w, "  - {} leading blank line(s)", count)?;
             }
             ProblemKind::ZeroWidthCharacter => {
-                println!("  - zero-width character at line {}", problem.line);
+                writeln!(w, "  - zero-width character at line {}", problem.line)?;
             }
             ProblemKind::ExcessiveBlankLines { found, limit } => {
-                println!(
+                writeln!(
+                    w,
                     "  - {} consecutive blank lines at line {} (limit: {})",
                     found, problem.line, limit
-                );
+                )?;
             }
             ProblemKind::CodeBlockRemnant => {
-                println!("  - code block remnant at line {}", problem.line);
+                writeln!(w, "  - code block remnant at line {}", problem.line)?;
             }
             ProblemKind::TodoComment => {
-                println!("  - TODO comment at line {}", problem.line);
+                writeln!(w, "  - TODO comment at line {}", problem.line)?;
             }
             ProblemKind::FixmeComment => {
-                println!("  - FIXME comment at line {}", problem.line);
+                writeln!(w, "  - FIXME comment at line {}", problem.line)?;
             }
             ProblemKind::DebugCode { pattern } => {
-                println!("  - debug code '{}' at line {}", pattern, problem.line);
+                writeln!(w, "  - debug code '{}' at line {}", pattern, problem.line)?;
             }
             ProblemKind::SecretPattern { hint } => {
-                println!("  - potential secret ({}) at line {}", hint, problem.line);
+                writeln!(
+                    w,
+                    "  - potential secret ({}) at line {}",
+                    hint, problem.line
+                )?;
             }
             ProblemKind::LongLine { length, limit } => {
-                println!(
+                writeln!(
+                    w,
                     "  - line {} is too long ({} > {} chars)",
                     problem.line, length, limit
-                );
+                )?;
             }
         }
     }
+    Ok(())
 }
 
 pub fn print_fix_result(

--- a/src/output.rs
+++ b/src/output.rs
@@ -113,30 +113,9 @@ pub fn print_check_result(
         );
 
         if result.has_changes() {
-            let orig_trimmed = original.trim_end_matches(['\n', '\r']);
-            let orig_trailing_newlines = original[orig_trimmed.len()..]
-                .chars()
-                .filter(|&c| c == '\n')
-                .count();
-            let result_trimmed = result.content.trim_end_matches(['\n', '\r']);
-            let result_trailing_newlines = result.content[result_trimmed.len()..]
-                .chars()
-                .filter(|&c| c == '\n')
-                .count();
-
-            if orig_trailing_newlines == 0 && result_trailing_newlines > 0 {
-                println!("  - missing EOF newline");
-            } else if orig_trailing_newlines > 1
-                && result_trailing_newlines < orig_trailing_newlines
-            {
-                println!("  - extra trailing newline(s) removed");
-            }
-
-            for (i, orig_line) in original.lines().enumerate() {
-                if orig_line.len() != orig_line.trim_end().len() {
-                    println!("  - trailing whitespace at line {}", i + 1);
-                }
-            }
+            let stdout = io::stdout();
+            print_change_summary_to(&mut stdout.lock(), original, &result.content)
+                .expect("failed to write to stdout");
         }
     }
 
@@ -145,10 +124,45 @@ pub fn print_check_result(
     print_problems_to(&mut stdout.lock(), &result.problems).expect("failed to write to stdout");
 }
 
+/// Prints the content-diff-derived summary lines (missing EOF newline, extra
+/// trailing newlines, trailing whitespace) that Normal-mode check output
+/// shows in place of a diff. Shared by file-mode check output (to stdout)
+/// and `--stdin --check` without `--diff` (to stderr, since stdin's stdout
+/// is reserved for normalized content only - issue #38) - both need these
+/// bullets since fix-only problems never populate `result.problems` (issue
+/// #79).
+pub fn print_change_summary_to<W: Write>(
+    w: &mut W,
+    original: &str,
+    result_content: &str,
+) -> io::Result<()> {
+    let orig_trimmed = original.trim_end_matches(['\n', '\r']);
+    let orig_trailing_newlines = original[orig_trimmed.len()..]
+        .chars()
+        .filter(|&c| c == '\n')
+        .count();
+    let result_trimmed = result_content.trim_end_matches(['\n', '\r']);
+    let result_trailing_newlines = result_content[result_trimmed.len()..]
+        .chars()
+        .filter(|&c| c == '\n')
+        .count();
+
+    if orig_trailing_newlines == 0 && result_trailing_newlines > 0 {
+        writeln!(w, "  - missing EOF newline")?;
+    } else if orig_trailing_newlines > 1 && result_trailing_newlines < orig_trailing_newlines {
+        writeln!(w, "  - extra trailing newline(s) removed")?;
+    }
+
+    for (i, orig_line) in original.lines().enumerate() {
+        if orig_line.len() != orig_line.trim_end().len() {
+            writeln!(w, "  - trailing whitespace at line {}", i + 1)?;
+        }
+    }
+    Ok(())
+}
+
 /// Prints the per-problem diagnostic list (e.g. "- TODO comment at line 3").
-/// Shared by file-mode check output (to stdout) and `--stdin --check`
-/// diagnostics (to stderr, since stdin's stdout is reserved for normalized
-/// content only - issue #38).
+/// Shared by file-mode check output and `--stdin --check` (issue #38, #79).
 pub fn print_problems_to<W: Write>(w: &mut W, problems: &[Problem]) -> io::Result<()> {
     for problem in problems {
         match &problem.kind {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1422,9 +1422,11 @@ fn test_stdin_check_diff_no_content_change_omits_diff_header() {
 }
 
 #[test]
-fn test_stdin_check_diff_with_content_change_still_shows_diff() {
-    // Regression test for issue #79: real content changes must still produce
-    // a diff on stderr (no regression from the no-op-diff guard added above).
+fn test_stdin_check_diff_with_content_change_shows_diff_and_problem() {
+    // Regression test for issue #79: when both a content change and a
+    // detection-only problem are present, --diff must still show the diff
+    // (no regression from the no-op-diff guard) and the problem list must
+    // still run alongside it.
     use std::io::Write;
     use std::process::Stdio;
 
@@ -1432,6 +1434,47 @@ fn test_stdin_check_diff_with_content_change_still_shows_diff() {
         .arg("--stdin")
         .arg("--check")
         .arg("--diff")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"TODO: x  \n")
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        stderr.contains("--- stdin") && stderr.contains("+++ stdin"),
+        "diff header missing on real content change: {stderr}"
+    );
+    assert!(
+        stderr.contains("TODO comment at line 1"),
+        "problem diagnostic missing from stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_stdin_check_fix_only_problem_prints_summary_without_diff() {
+    // Regression test for issue #79: a fix-only problem (trailing whitespace,
+    // missing EOF newline, ...) never populates result.problems, so without
+    // this summary --stdin --check exited 1 with zero diagnostics for the
+    // most common trigger.
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1452,11 +1495,55 @@ fn test_stdin_check_diff_with_content_change_still_shows_diff() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
     assert!(
-        stderr.contains("--- stdin"),
-        "diff header missing on real content change: {stderr}"
+        stderr.contains("trailing whitespace at line 1"),
+        "fix-only diagnostic missing from stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_stdin_check_diff_masked_to_no_diff_omits_diff_header() {
+    // Regression test for issue #79: masking a secret line can make the
+    // masked original and masked normalized content identical even though
+    // result.has_changes() is true (the unmasked content did change, e.g.
+    // trailing whitespace on the secret line itself) - the diff header must
+    // still be omitted in that case, and the secret value must never reach
+    // stderr.
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
+        .arg("--diff")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"aws_secret_access_key = \"AKIAABCDEFGHIJKLMNOP\"  \n")
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        !stderr.contains("--- stdin"),
+        "diff header should be omitted when masking collapses the diff: {stderr}"
     );
     assert!(
-        stderr.contains("+++ stdin"),
-        "diff header missing on real content change: {stderr}"
+        !stderr.contains("AKIAABCDEFGHIJKLMNOP"),
+        "secret value must never reach stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("potential secret"),
+        "secret hint missing from stderr: {stderr}"
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1501,6 +1501,39 @@ fn test_stdin_check_fix_only_problem_prints_summary_without_diff() {
 }
 
 #[test]
+fn test_stdin_check_crlf_only_change_prints_diagnostic() {
+    // Regression test for issue #79: CRLF normalization is a fix-only
+    // transform that fires neither a Problem entry (no ProblemKind variant
+    // for it) nor a print_change_summary_to bullet (trailing-newline counts
+    // and trimmed trailing-whitespace lines are unaffected by CRLF->LF), so
+    // it used to leave stderr completely empty despite the exit 1.
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child.stdin.take().unwrap().write_all(b"hello\r\n").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        !stderr.is_empty(),
+        "stderr must not be empty on a CRLF-only check failure"
+    );
+}
+
+#[test]
 fn test_stdin_check_diff_masked_to_no_diff_omits_diff_header() {
     // Regression test for issue #79: masking a secret line can make the
     // masked original and masked normalized content identical even though

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1354,3 +1354,109 @@ fn test_stdin_check_mode_passes_clean_input() {
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success());
 }
+
+#[test]
+fn test_stdin_check_detection_only_prints_problem_to_stderr() {
+    // Regression test for issue #79: detection-only problems (no content
+    // changes) used to exit 1 with zero diagnostics anywhere.
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child.stdin.take().unwrap().write_all(b"TODO: x\n").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        stderr.contains("TODO comment at line 1"),
+        "problem diagnostic missing from stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_stdin_check_diff_no_content_change_omits_diff_header() {
+    // Regression test for issue #79: --stdin --check --diff used to print an
+    // empty `--- stdin` / `+++ stdin` header even when nothing but a
+    // detection-only problem was found (no content diff to show).
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
+        .arg("--diff")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child.stdin.take().unwrap().write_all(b"TODO: x\n").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        !stderr.contains("--- stdin"),
+        "diff header should be omitted with no content change: {stderr}"
+    );
+    assert!(
+        stderr.contains("TODO comment at line 1"),
+        "problem diagnostic missing from stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_stdin_check_diff_with_content_change_still_shows_diff() {
+    // Regression test for issue #79: real content changes must still produce
+    // a diff on stderr (no regression from the no-op-diff guard added above).
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = fini_cmd()
+        .arg("--stdin")
+        .arg("--check")
+        .arg("--diff")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"hello   \n")
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout must stay clean: {stdout}");
+    assert!(
+        stderr.contains("--- stdin"),
+        "diff header missing on real content change: {stderr}"
+    );
+    assert!(
+        stderr.contains("+++ stdin"),
+        "diff header missing on real content change: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- `--stdin --check` used to exit 1 with zero diagnostics for problems that never touch `result.content`: detection-only problems (TODO/FIXME/debug/secret) and fix-only transforms like trailing-whitespace/EOF-newline/CRLF normalization never showed up in a diff, and had no other path to stderr.
- Extracted `output::print_problems_to<W: Write>` (the per-problem diagnostic list) and `output::print_change_summary_to<W: Write>` (the missing-EOF-newline / extra-trailing-newline / trailing-whitespace bullets) out of `print_check_result`, and reused both from `handle_stdin` against stderr. stdout stays reserved for normalized/passthrough content only, per issue #38's convention.
- `handle_stdin`'s non-diff check branch now prints an unconditional `Error: stdin` header (mirroring file-mode's `Error: <path>`), guaranteeing non-empty stderr on every check failure even for a fix-only transform with no diagnostic line of its own (e.g. CRLF-only input).
- `--stdin --check --diff` no longer prints an empty `--- stdin`/`+++ stdin` header. It's now gated on the *masked* content pair actually differing, not just `result.has_changes()`, closing a case where masking a changed secret line could make both sides of the diff identical.
- All stdin check-mode diagnostics (diff, change summary, problem list) are now gated behind `!cli.quiet`, matching file-mode's Quiet output. Note: this is a small behavior change: `--stdin --check --diff --quiet` previously still printed the diff; it's now fully silent, consistent with quiet meaning "no diagnostic output" everywhere else in the tool.

## Test plan
- [x] `cargo test` (176 unit + 64 integration tests, all passing)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] New regression tests covering: detection-only problems on stderr; diff header omitted with no content change; diff + problem list both showing when both fire; fix-only problems (trailing whitespace) printing a diagnostic without `--diff`; masked-diff collapse omitting the header while still surfacing the secret hint (never the raw value); CRLF-only input still producing a non-empty diagnostic
- [x] Two independent code-reviewer passes, findings addressed each round
- [x] Manually reproduced the issue's repro commands before and after the fix

Closes #79

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd
