### PR TITLE
fix(detect): stop trailing skip-pattern comments from bypassing secret detection

### DIFF
--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -169,7 +169,7 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
 }
 
 /// A skip pattern only excuses a match when it occurs within the matched text
-/// itself — e.g. `token = "process.env.API_TOKEN"`, a placeholder — not when
+/// itself — e.g. `api_key = "process.env.API_KEY"`, a placeholder — not when
 /// it sits outside the match, such as an unrelated trailing comment
 /// (`password = "hunter2hunter2"  # ${`). Checking the whole line let a skip
 /// marker anywhere on the line defeat detection entirely (issue #77).
@@ -185,14 +185,17 @@ pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
         .enumerate()
         .filter_map(|(line_idx, line)| {
             patterns.iter().find_map(|pattern| {
-                let m = pattern.regex.find(line)?;
-                if skip_pattern_within_match(m.as_str()) {
-                    return None;
-                }
-                Some(Problem {
-                    line: line_idx + 1,
-                    kind: ProblemKind::SecretPattern { hint: pattern.hint },
-                })
+                // find_iter (not find): a skipped placeholder match must not
+                // short-circuit past a later, unrelated real secret matching
+                // the same pattern on the same line.
+                pattern
+                    .regex
+                    .find_iter(line)
+                    .find(|m| !skip_pattern_within_match(m.as_str()))
+                    .map(|_| Problem {
+                        line: line_idx + 1,
+                        kind: ProblemKind::SecretPattern { hint: pattern.hint },
+                    })
             })
         })
         .collect()
@@ -359,6 +362,28 @@ mod tests {
     fn test_secret_skip_placeholder() {
         assert!(detect_secret_patterns("api_key = \"<your-api-key>\"\n").is_empty());
         assert!(detect_secret_patterns("token = \"${API_TOKEN}\"\n").is_empty());
+    }
+
+    // A quoted value that itself matches a skip pattern (unlike the cases
+    // above, which never match any secret regex regardless of skip logic)
+    // is still legitimately skipped from detection.
+    #[test]
+    fn test_secret_skip_quoted_env_reference() {
+        assert!(detect_secret_patterns("api_key = \"process.env.API_KEY\"\n").is_empty());
+    }
+
+    // issue #77: a skipped placeholder occurrence must not shadow a later,
+    // unrelated real secret matching the same pattern on the same line.
+    #[test]
+    fn test_secret_skip_does_not_shadow_later_real_secret_same_line() {
+        let problems = detect_secret_patterns(
+            "api_key = \"process.env.API_KEY\", password = \"hunter2hunter2\"\n",
+        );
+        assert_eq!(problems.len(), 1);
+        assert!(matches!(
+            &problems[0].kind,
+            ProblemKind::SecretPattern { hint } if *hint == "hardcoded secret"
+        ));
     }
 
     // issue #77: a skip pattern trailing a real secret as an unrelated

--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -168,14 +168,13 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
         .collect()
 }
 
-/// A skip pattern only excuses a match when it occurs before or within the
-/// matched text itself — e.g. `token = "${API_TOKEN}"`, a placeholder — not
-/// when it trails a real secret as an unrelated comment, e.g.
-/// `password = "hunter2hunter2"  # ${`. Checking the whole line let a skip
-/// marker appended *after* the value defeat detection entirely (issue #77).
-fn skip_pattern_before_match_end(line: &str, match_end: usize) -> bool {
-    let prefix = &line[..match_end];
-    SECRET_SKIP_PATTERNS.iter().any(|p| prefix.contains(p))
+/// A skip pattern only excuses a match when it occurs within the matched text
+/// itself — e.g. `token = "process.env.API_TOKEN"`, a placeholder — not when
+/// it sits outside the match, such as an unrelated trailing comment
+/// (`password = "hunter2hunter2"  # ${`). Checking the whole line let a skip
+/// marker anywhere on the line defeat detection entirely (issue #77).
+fn skip_pattern_within_match(matched: &str) -> bool {
+    SECRET_SKIP_PATTERNS.iter().any(|p| matched.contains(p))
 }
 
 pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
@@ -187,7 +186,7 @@ pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
         .filter_map(|(line_idx, line)| {
             patterns.iter().find_map(|pattern| {
                 let m = pattern.regex.find(line)?;
-                if skip_pattern_before_match_end(line, m.end()) {
+                if skip_pattern_within_match(m.as_str()) {
                     return None;
                 }
                 Some(Problem {
@@ -435,9 +434,23 @@ mod tests {
     }
 
     #[test]
-    fn test_mask_secret_lines_keeps_skip_patterns() {
+    fn test_mask_secret_lines_leaves_non_matching_line_untouched() {
+        // Unquoted, so it never matches the "hardcoded secret" value pattern in
+        // the first place — this is not exercising skip-pattern behavior.
         let content = "password = process.env.PASSWORD\n";
         assert_eq!(mask_secret_lines(content), content);
+    }
+
+    // issue #77: masking must never depend on SECRET_SKIP_PATTERNS — even a
+    // line that legitimately matches a skip pattern (and is therefore not
+    // *reported*) still gets masked if it also matches a secret regex.
+    #[test]
+    fn test_mask_secret_lines_masks_even_when_skip_pattern_present() {
+        let content = "api_key = \"process.env.API_KEY\"\n";
+        assert!(detect_secret_patterns(content).is_empty());
+        let masked = mask_secret_lines(content);
+        assert!(!masked.contains("process.env.API_KEY"));
+        assert!(masked.contains("[line masked: potential hardcoded secret]"));
     }
 
     #[test]

--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -168,6 +168,16 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
         .collect()
 }
 
+/// A skip pattern only excuses a match when it occurs before or within the
+/// matched text itself — e.g. `token = "${API_TOKEN}"`, a placeholder — not
+/// when it trails a real secret as an unrelated comment, e.g.
+/// `password = "hunter2hunter2"  # ${`. Checking the whole line let a skip
+/// marker appended *after* the value defeat detection entirely (issue #77).
+fn skip_pattern_before_match_end(line: &str, match_end: usize) -> bool {
+    let prefix = &line[..match_end];
+    SECRET_SKIP_PATTERNS.iter().any(|p| prefix.contains(p))
+}
+
 pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
     let patterns = &*SECRET_PATTERNS;
 
@@ -175,17 +185,16 @@ pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
         .lines()
         .enumerate()
         .filter_map(|(line_idx, line)| {
-            if SECRET_SKIP_PATTERNS.iter().any(|p| line.contains(p)) {
-                return None;
-            }
-
-            patterns
-                .iter()
-                .find(|p| p.regex.is_match(line))
-                .map(|pattern| Problem {
+            patterns.iter().find_map(|pattern| {
+                let m = pattern.regex.find(line)?;
+                if skip_pattern_before_match_end(line, m.end()) {
+                    return None;
+                }
+                Some(Problem {
                     line: line_idx + 1,
                     kind: ProblemKind::SecretPattern { hint: pattern.hint },
                 })
+            })
         })
         .collect()
 }
@@ -195,20 +204,21 @@ pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
 /// The checker deliberately reports secrets hint-only (the matched value never
 /// enters a `Problem`); diff output must honor the same contract, including
 /// unchanged context lines, so raw values never reach CI logs (issue #44).
+///
+/// Masking ignores `SECRET_SKIP_PATTERNS` entirely (unlike `detect_secret_patterns`):
+/// a skip pattern only decides whether a match is *reported*, never whether a
+/// diff shows raw secret-shaped text — an unrelated trailing comment (or any
+/// other skip-pattern occurrence) must not un-mask a real secret (issue #77).
 pub(super) fn mask_secret_lines(content: &str) -> String {
     let patterns = &*SECRET_PATTERNS;
     let mut out = String::with_capacity(content.len());
 
     for line in content.split_inclusive('\n') {
         let text = line.strip_suffix('\n').unwrap_or(line);
-        let hint = if SECRET_SKIP_PATTERNS.iter().any(|p| text.contains(p)) {
-            None
-        } else {
-            patterns
-                .iter()
-                .find(|p| p.regex.is_match(text))
-                .map(|p| p.hint)
-        };
+        let hint = patterns
+            .iter()
+            .find(|p| p.regex.is_match(text))
+            .map(|p| p.hint);
 
         match hint {
             Some(hint) => {
@@ -350,6 +360,29 @@ mod tests {
     fn test_secret_skip_placeholder() {
         assert!(detect_secret_patterns("api_key = \"<your-api-key>\"\n").is_empty());
         assert!(detect_secret_patterns("token = \"${API_TOKEN}\"\n").is_empty());
+    }
+
+    // issue #77: a skip pattern trailing a real secret as an unrelated
+    // comment must not bypass detection or diff masking.
+    #[test]
+    fn test_secret_trailing_comment_does_not_bypass_detection() {
+        let problems = detect_secret_patterns("password = \"hunter2hunter2\"  # ${\n");
+        assert_eq!(problems.len(), 1);
+        assert!(matches!(
+            &problems[0].kind,
+            ProblemKind::SecretPattern { hint } if *hint == "hardcoded secret"
+        ));
+
+        let problems =
+            detect_secret_patterns("aws_access_key_id = \"AKIAQWERTYUIOPASDFGH\"  // {{\n");
+        assert_eq!(problems.len(), 1);
+    }
+
+    #[test]
+    fn test_secret_trailing_comment_still_masked() {
+        let masked = mask_secret_lines("password = \"hunter2hunter2\"  # ${\n");
+        assert!(!masked.contains("hunter2hunter2"));
+        assert!(masked.contains("[line masked: potential hardcoded secret]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #77. `SECRET_SKIP_PATTERNS` (`process.env`, `${`, `{{`, etc.) checked whether the pattern appeared *anywhere* in the line, so a trailing comment like `# ${` after a real secret defeated both `--check` detection and `--diff` masking, with no audit trail.

- `detect_secret_patterns`: the skip check is now scoped to the matched text itself (`regex::Match::as_str()`) — a skip pattern only excuses a match when it occurs *within* what the secret regex actually matched (a genuine placeholder like `api_key = "process.env.API_KEY"`), not when it sits outside the match as an unrelated comment before or after it.
- `mask_secret_lines`: now ignores skip patterns entirely and always masks a secret-shaped match, per the issue's guidance that masking must never depend on the skip-pattern check — a skip pattern should only affect whether something is *reported*, never whether a diff shows raw secret-shaped text.

Note on scoping: none of `SECRET_SKIP_PATTERNS`' special characters (`{`, `<`, `>`) can appear inside a secret regex's own value character class, so a marker like `${...}` or `<your-...>` can only ever sit *outside* a match, never within one — meaning those specific tokens' "skip" behavior was already effectively silent-by-construction for the five original test literals (they don't match the secret regexes at all with or without this fix). The skip path is genuinely live, though, for patterns without special characters (e.g. `process.env`, `getenv`) *when quoted* — `api_key = "process.env.API_KEY"` does match the hardcoded-secret regex and is legitimately skipped from detection (still masked in diffs). Per the issue's scoping, that legitimate placeholder-skip path is fine to remain silent (no stderr audit trail) — the bug being fixed here is specifically the "marker outside the match" bypass.

## Test plan
- [x] `cargo test` — 179 lib tests + 58 integration tests pass, including new regression tests: `test_secret_trailing_comment_does_not_bypass_detection`, `test_secret_trailing_comment_still_masked`, `test_mask_secret_lines_masks_even_when_skip_pattern_present`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manual repro of all three cases from the issue: `p1.txt`/`p2.txt`/`p3.txt` now all correctly exit 1 with detection; `--diff` masks the trailing-comment case instead of leaking the raw value

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd