### PR TITLE
fix(release): validate tag/version before homebrew formula injection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,3 +53,10 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Test update-homebrew-formula.sh
+        run: bash scripts/test-update-homebrew-formula.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,7 @@ jobs:
           ref: main
 
       - name: Validate tag format
+        shell: bash
         run: |
           set -euo pipefail
           if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,10 @@ jobs:
           generate_release_notes: true
 
   update-homebrew-formula:
-    needs: release
+    # publish-crate has already validated GITHUB_REF_NAME against Cargo.toml's
+    # version by the time this runs, so a malformed/malicious tag can never
+    # reach this job's push-to-main step without also failing that check.
+    needs: [release, publish-crate]
     runs-on: ubuntu-latest
     permissions:
       contents: write   # push the regenerated formula back to main
@@ -109,6 +112,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
+
+      - name: Validate tag format
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match expected format vX.Y.Z[-prerelease]" >&2
+            exit 1
+          fi
 
       - name: Download release assets
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,9 +101,10 @@ jobs:
           generate_release_notes: true
 
   update-homebrew-formula:
-    # publish-crate has already validated GITHUB_REF_NAME against Cargo.toml's
-    # version by the time this runs, so a malformed/malicious tag can never
-    # reach this job's push-to-main step without also failing that check.
+    # Defense-in-depth sequencing: the primary control is this job's own
+    # "Validate tag format" step below. Depending on publish-crate too means
+    # a tag that fails its Cargo.toml version match also blocks this job,
+    # even though that check doesn't itself constrain the tag's charset.
     needs: [release, publish-crate]
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/test-update-homebrew-formula.sh
+++ b/scripts/test-update-homebrew-formula.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test for scripts/update-homebrew-formula.sh's version validation
+# (issue #90: a malicious/malformed tag name must never reach the Ruby
+# heredoc that embeds it into HomebrewFormula/fini.rb).
+#
+# Assets are built as real (valid) release assets so the run reaches the
+# version-embedding step for every case; without the validation fix this
+# test fails because the malicious cases would successfully rewrite the
+# formula with injected content.
+#
+# Run manually: bash scripts/test-update-homebrew-formula.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/update-homebrew-formula.sh"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/fini-homebrew-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256() { sha256sum "$@"; }
+else
+  SHA256() { shasum -a 256 "$@"; }
+fi
+
+# Isolated fake repo root so a failed run can never touch the real
+# HomebrewFormula/fini.rb.
+FAKE_REPO="$WORKDIR/repo"
+mkdir -p "$FAKE_REPO/scripts" "$FAKE_REPO/HomebrewFormula"
+cp "$SCRIPT" "$FAKE_REPO/scripts/update-homebrew-formula.sh"
+FORMULA="$FAKE_REPO/HomebrewFormula/fini.rb"
+
+ASSETS_DIR="$WORKDIR/assets"
+mkdir -p "$ASSETS_DIR"
+for target in x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+  echo "fake binary for $target" > "$ASSETS_DIR/fini-$target.tar.gz"
+done
+(cd "$ASSETS_DIR" && SHA256 fini-*.tar.gz > checksums.txt)
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+reset_formula() {
+  echo "sentinel: pre-existing content" > "$FORMULA"
+}
+
+run_script() {
+  (cd "$FAKE_REPO" && bash scripts/update-homebrew-formula.sh "$1" "$ASSETS_DIR")
+}
+
+# --- Malicious tag-shaped argument must be rejected (exit 2), formula untouched ---
+reset_formula
+MALICIOUS='0.5.0"; echo pwned; x="'
+set +e
+run_script "$MALICIOUS" >/dev/null 2>&1
+STATUS=$?
+set -e
+[ "$STATUS" -eq 2 ] || fail "malicious version '$MALICIOUS' did not exit 2 (got $STATUS)"
+[ "$(cat "$FORMULA")" = "sentinel: pre-existing content" ] || fail "formula file was modified by malicious version '$MALICIOUS'"
+echo "PASS: malicious version (quote injection) rejected with exit 2, formula untouched"
+
+# --- Another injection shape (semicolon + backtick) ---
+reset_formula
+MALICIOUS2='1.0.0; rm -rf /`'
+set +e
+run_script "$MALICIOUS2" >/dev/null 2>&1
+STATUS=$?
+set -e
+[ "$STATUS" -eq 2 ] || fail "malicious version '$MALICIOUS2' did not exit 2 (got $STATUS)"
+[ "$(cat "$FORMULA")" = "sentinel: pre-existing content" ] || fail "formula file was modified by malicious version '$MALICIOUS2'"
+echo "PASS: malicious version (shell metacharacters) rejected with exit 2, formula untouched"
+
+# --- Edge cases: empty string, trailing newline, "v" prefix left on ---
+for bad in "" $'0.5.0\n' "v0.5.0"; do
+  reset_formula
+  set +e
+  run_script "$bad" >/dev/null 2>&1
+  STATUS=$?
+  set -e
+  [ "$STATUS" -eq 2 ] || fail "invalid version '$bad' did not exit 2 (got $STATUS)"
+  [ "$(cat "$FORMULA")" = "sentinel: pre-existing content" ] || fail "formula file was modified by invalid version '$bad'"
+done
+echo "PASS: empty string, trailing newline, and unstripped 'v' prefix all rejected"
+
+# --- Well-formed versions must still work ---
+reset_formula
+run_script "0.5.0" >/dev/null 2>&1
+grep -q 'version "0.5.0"' "$FORMULA" || fail "valid version '0.5.0' was not embedded in the formula"
+echo "PASS: valid version '0.5.0' accepted and embedded"
+
+reset_formula
+run_script "0.5.0-rc.1" >/dev/null 2>&1
+grep -q 'version "0.5.0-rc.1"' "$FORMULA" || fail "valid pre-release version '0.5.0-rc.1' was not embedded in the formula"
+echo "PASS: valid pre-release version '0.5.0-rc.1' accepted and embedded"
+
+echo "All tests passed."

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -20,6 +20,15 @@ ASSETS_DIR="$2"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FORMULA="$REPO_ROOT/HomebrewFormula/fini.rb"
 
+# VERSION is embedded verbatim into a Ruby heredoc below (version "$VERSION"),
+# so it must be restricted to a safe charset before that happens — this
+# guards direct/manual invocations even though the release workflow also
+# validates the tag before calling this script.
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "error: invalid version '$VERSION' (expected X.Y.Z or X.Y.Z-prerelease)" >&2
+  exit 2
+fi
+
 if command -v sha256sum >/dev/null 2>&1; then
   SHA256() { sha256sum "$@"; }
 else


### PR DESCRIPTION
## Summary

Closes #90.

`update-homebrew-formula` stripped the `v` prefix off `GITHUB_REF_NAME` and passed it unvalidated to `scripts/update-homebrew-formula.sh`, which embeds it verbatim into a Ruby heredoc (`version "$VERSION"`) in `HomebrewFormula/fini.rb` and pushes directly to `main` with a bot token. Git tag names permit `"` and `;`, so a maliciously crafted tag could inject Ruby into the formula and land it on `main` without PR review or branch protection. The only existing tag-format check lived in the separate `publish-crate` job, and `update-homebrew-formula` did not depend on it (`needs: release` only).

- Adds a strict tag-format assertion (`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`) as a step at the start of the `update-homebrew-formula` job.
- Adds the same validation (on the stripped version) inside `scripts/update-homebrew-formula.sh` itself, for defense in depth in case the script is ever invoked outside the workflow.
- Changes `update-homebrew-formula`'s `needs:` from `release` to `[release, publish-crate]`, so the job can never run without `publish-crate`'s existing tag-vs-`Cargo.toml` check having already passed. **Behavior change**: a `cargo publish` failure now also blocks the Homebrew formula update (this is the intended effect of the issue's fix).
- Adds `scripts/test-update-homebrew-formula.sh`, a standalone regression test (no existing shell-test convention in this repo) that builds valid fake release assets, then asserts malicious/malformed version arguments (quote injection, shell metacharacters, empty string, trailing newline, unstripped `v` prefix) exit 2 without touching the formula file, and that well-formed versions (including a pre-release suffix) are still accepted and correctly embedded. Verified the test actually catches the regression by temporarily reverting the script-level check and confirming the test fails.

## Test plan

- [x] `bash scripts/test-update-homebrew-formula.sh` — all cases pass; confirmed the malicious-input case fails without the fix (proving the test is not vacuous)
- [x] `cargo test` — 176 unit + 58 integration tests, all pass (unaffected, workflow/script-only change)
- [x] `bash -n scripts/update-homebrew-formula.sh` and `bash -n scripts/test-update-homebrew-formula.sh` — syntax OK
- [x] `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yaml')"` — YAML valid
- [ ] No tag pushed / no release triggered as part of this change (validation-logic-only)

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd