### PR TITLE
fix: remap detection line numbers to the original file

### DIFF
--- a/src/normalize/detect.rs
+++ b/src/normalize/detect.rs
@@ -103,20 +103,23 @@ fn is_valid_marker(line: &str, marker: &str) -> bool {
 /// Returns the two problem kinds in separate vecs, each in line order, so
 /// callers that gate TODO/FIXME detection independently can extend their
 /// combined problem list with either or both without reordering results.
-pub(super) fn detect_todo_and_fixme_comments(content: &str) -> (Vec<Problem>, Vec<Problem>) {
+pub(super) fn detect_todo_and_fixme_comments(
+    content: &str,
+    line_map: &[usize],
+) -> (Vec<Problem>, Vec<Problem>) {
     let mut todos = Vec::new();
     let mut fixmes = Vec::new();
 
     for (line_idx, line) in content.lines().enumerate() {
         if is_valid_marker(line, "TODO") {
             todos.push(Problem {
-                line: line_idx + 1,
+                line: line_map[line_idx],
                 kind: ProblemKind::TodoComment,
             });
         }
         if is_valid_marker(line, "FIXME") {
             fixmes.push(Problem {
-                line: line_idx + 1,
+                line: line_map[line_idx],
                 kind: ProblemKind::FixmeComment,
             });
         }
@@ -147,7 +150,11 @@ fn contains_word_boundary(line: &str, pattern: &str) -> bool {
     false
 }
 
-pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem> {
+pub(super) fn detect_debug_code(
+    content: &str,
+    strict_mode: bool,
+    line_map: &[usize],
+) -> Vec<Problem> {
     let extra: &[&str] = if strict_mode { STRICT_DEBUG_EXTRA } else { &[] };
 
     content
@@ -159,7 +166,7 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
                 .chain(extra.iter())
                 .find(|p| contains_word_boundary(line, p))
                 .map(|pattern| Problem {
-                    line: line_idx + 1,
+                    line: line_map[line_idx],
                     kind: ProblemKind::DebugCode {
                         pattern: pattern.trim_end_matches('('),
                     },
@@ -168,7 +175,7 @@ pub(super) fn detect_debug_code(content: &str, strict_mode: bool) -> Vec<Problem
         .collect()
 }
 
-pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
+pub(super) fn detect_secret_patterns(content: &str, line_map: &[usize]) -> Vec<Problem> {
     let patterns = &*SECRET_PATTERNS;
 
     content
@@ -183,7 +190,7 @@ pub(super) fn detect_secret_patterns(content: &str) -> Vec<Problem> {
                 .iter()
                 .find(|p| p.regex.is_match(line))
                 .map(|pattern| Problem {
-                    line: line_idx + 1,
+                    line: line_map[line_idx],
                     kind: ProblemKind::SecretPattern { hint: pattern.hint },
                 })
         })
@@ -226,7 +233,11 @@ pub(super) fn mask_secret_lines(content: &str) -> String {
     out
 }
 
-pub(super) fn check_line_length(content: &str, max_length: usize) -> Vec<Problem> {
+pub(super) fn check_line_length(
+    content: &str,
+    max_length: usize,
+    line_map: &[usize],
+) -> Vec<Problem> {
     content
         .lines()
         .enumerate()
@@ -237,7 +248,7 @@ pub(super) fn check_line_length(content: &str, max_length: usize) -> Vec<Problem
             }
             let length = line.chars().count();
             (length > max_length).then_some(Problem {
-                line: line_idx + 1,
+                line: line_map[line_idx],
                 kind: ProblemKind::LongLine {
                     length,
                     limit: max_length,
@@ -251,43 +262,66 @@ pub(super) fn check_line_length(content: &str, max_length: usize) -> Vec<Problem
 mod tests {
     use super::*;
 
+    /// Identity map for tests that don't exercise line-number remapping.
+    fn identity_map(content: &str) -> Vec<usize> {
+        (1..=content.lines().count()).collect()
+    }
+
     #[test]
     fn test_todo_basic() {
-        let (todos, _) = detect_todo_and_fixme_comments("// TODO: fix this\n");
+        let content = "// TODO: fix this\n";
+        let (todos, _) = detect_todo_and_fixme_comments(content, &identity_map(content));
         assert_eq!(todos.len(), 1);
         assert_eq!(todos[0].line, 1);
     }
 
     #[test]
     fn test_todo_case_insensitive() {
-        assert_eq!(detect_todo_and_fixme_comments("// todo: fix\n").0.len(), 1);
-        assert_eq!(detect_todo_and_fixme_comments("// Todo fix\n").0.len(), 1);
+        let content = "// todo: fix\n";
+        assert_eq!(
+            detect_todo_and_fixme_comments(content, &identity_map(content))
+                .0
+                .len(),
+            1
+        );
+        let content = "// Todo fix\n";
+        assert_eq!(
+            detect_todo_and_fixme_comments(content, &identity_map(content))
+                .0
+                .len(),
+            1
+        );
     }
 
     #[test]
     fn test_todo_requires_word_boundary() {
-        assert!(detect_todo_and_fixme_comments("use todoist;\n")
-            .0
-            .is_empty());
+        let content = "use todoist;\n";
+        assert!(
+            detect_todo_and_fixme_comments(content, &identity_map(content))
+                .0
+                .is_empty()
+        );
     }
 
     #[test]
     fn test_fixme_detected() {
-        let (_, fixmes) = detect_todo_and_fixme_comments("# FIXME: broken\n");
+        let content = "# FIXME: broken\n";
+        let (_, fixmes) = detect_todo_and_fixme_comments(content, &identity_map(content));
         assert_eq!(fixmes.len(), 1);
     }
 
     #[test]
     fn test_todo_and_fixme_single_pass_separates_kinds() {
-        let (todos, fixmes) =
-            detect_todo_and_fixme_comments("// TODO: first\n// FIXME: second\n// TODO: third\n");
+        let content = "// TODO: first\n// FIXME: second\n// TODO: third\n";
+        let (todos, fixmes) = detect_todo_and_fixme_comments(content, &identity_map(content));
         assert_eq!(todos.iter().map(|p| p.line).collect::<Vec<_>>(), [1, 3]);
         assert_eq!(fixmes.iter().map(|p| p.line).collect::<Vec<_>>(), [2]);
     }
 
     #[test]
     fn test_debug_console_log() {
-        let problems = detect_debug_code("console.log('test');\n", false);
+        let content = "console.log('test');\n";
+        let problems = detect_debug_code(content, false, &identity_map(content));
         assert_eq!(problems.len(), 1);
         assert!(matches!(
             &problems[0].kind,
@@ -297,34 +331,45 @@ mod tests {
 
     #[test]
     fn test_debug_dbg_macro() {
-        let problems = detect_debug_code("dbg!(value);\n", false);
+        let content = "dbg!(value);\n";
+        let problems = detect_debug_code(content, false, &identity_map(content));
         assert_eq!(problems.len(), 1);
     }
 
     #[test]
     fn test_debug_strict_includes_console_error() {
-        assert!(detect_debug_code("console.error('fail');\n", false).is_empty());
-        assert_eq!(detect_debug_code("console.error('fail');\n", true).len(), 1);
+        let content = "console.error('fail');\n";
+        assert!(detect_debug_code(content, false, &identity_map(content)).is_empty());
+        assert_eq!(
+            detect_debug_code(content, true, &identity_map(content)).len(),
+            1
+        );
     }
 
     #[test]
     fn test_debug_strict_includes_eprintln() {
         // "eprintln!(" contains "println!(" as a substring, but not at a word
         // boundary (preceded by 'e'), so non-strict mode must not flag it.
-        assert!(detect_debug_code("eprintln!(\"fail\");\n", false).is_empty());
-        assert_eq!(detect_debug_code("eprintln!(\"fail\");\n", true).len(), 1);
+        let content = "eprintln!(\"fail\");\n";
+        assert!(detect_debug_code(content, false, &identity_map(content)).is_empty());
+        assert_eq!(
+            detect_debug_code(content, true, &identity_map(content)).len(),
+            1
+        );
     }
 
     #[test]
     fn test_debug_print_requires_word_boundary() {
-        assert!(detect_debug_code("sprint(x);\n", false).is_empty());
-        assert!(detect_debug_code("pprint(x);\n", false).is_empty());
+        let content = "sprint(x);\n";
+        assert!(detect_debug_code(content, false, &identity_map(content)).is_empty());
+        let content = "pprint(x);\n";
+        assert!(detect_debug_code(content, false, &identity_map(content)).is_empty());
     }
 
     #[test]
     fn test_secret_bearer_token() {
-        let problems =
-            detect_secret_patterns("Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9\n");
+        let content = "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9\n";
+        let problems = detect_secret_patterns(content, &identity_map(content));
         assert_eq!(problems.len(), 1);
         assert!(matches!(
             &problems[0].kind,
@@ -334,39 +379,45 @@ mod tests {
 
     #[test]
     fn test_secret_github_token() {
-        let problems =
-            detect_secret_patterns("token = \"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn\"\n");
+        let content = "token = \"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn\"\n";
+        let problems = detect_secret_patterns(content, &identity_map(content));
         assert_eq!(problems.len(), 1);
     }
 
     #[test]
     fn test_secret_skip_env_var_reference() {
-        assert!(detect_secret_patterns("password = process.env.PASSWORD\n").is_empty());
-        assert!(detect_secret_patterns("key = os.environ['API_KEY']\n").is_empty());
-        assert!(detect_secret_patterns("key = std::env::var(\"KEY\")\n").is_empty());
+        let content = "password = process.env.PASSWORD\n";
+        assert!(detect_secret_patterns(content, &identity_map(content)).is_empty());
+        let content = "key = os.environ['API_KEY']\n";
+        assert!(detect_secret_patterns(content, &identity_map(content)).is_empty());
+        let content = "key = std::env::var(\"KEY\")\n";
+        assert!(detect_secret_patterns(content, &identity_map(content)).is_empty());
     }
 
     #[test]
     fn test_secret_skip_placeholder() {
-        assert!(detect_secret_patterns("api_key = \"<your-api-key>\"\n").is_empty());
-        assert!(detect_secret_patterns("token = \"${API_TOKEN}\"\n").is_empty());
+        let content = "api_key = \"<your-api-key>\"\n";
+        assert!(detect_secret_patterns(content, &identity_map(content)).is_empty());
+        let content = "token = \"${API_TOKEN}\"\n";
+        assert!(detect_secret_patterns(content, &identity_map(content)).is_empty());
     }
 
     #[test]
     fn test_line_length_under_limit() {
-        assert!(check_line_length("short\n", 80).is_empty());
+        let content = "short\n";
+        assert!(check_line_length(content, 80, &identity_map(content)).is_empty());
     }
 
     #[test]
     fn test_line_length_at_limit() {
         let line = format!("{}\n", "a".repeat(80));
-        assert!(check_line_length(&line, 80).is_empty());
+        assert!(check_line_length(&line, 80, &identity_map(&line)).is_empty());
     }
 
     #[test]
     fn test_line_length_over_limit() {
         let line = format!("{}\n", "a".repeat(81));
-        let problems = check_line_length(&line, 80);
+        let problems = check_line_length(&line, 80, &identity_map(&line));
         assert_eq!(problems.len(), 1);
         assert!(matches!(
             &problems[0].kind,
@@ -382,13 +433,14 @@ mod tests {
         // 6 multibyte chars = 6 char count but 18 byte length
         // byte length > limit but char count <= limit should pass
         let line = "ああああああ\n";
-        assert!(check_line_length(line, 6).is_empty());
-        assert_eq!(check_line_length(line, 5).len(), 1);
+        assert!(check_line_length(line, 6, &identity_map(line)).is_empty());
+        assert_eq!(check_line_length(line, 5, &identity_map(line)).len(), 1);
     }
 
     #[test]
     fn test_multiple_debug_on_same_line_reports_first() {
-        let problems = detect_debug_code("console.log(dbg!(x));\n", false);
+        let content = "console.log(dbg!(x));\n";
+        let problems = detect_debug_code(content, false, &identity_map(content));
         assert_eq!(problems.len(), 1);
     }
 

--- a/src/normalize/fix.rs
+++ b/src/normalize/fix.rs
@@ -16,7 +16,7 @@ pub(super) fn normalize_line_endings(content: &str) -> String {
     content.replace("\r\n", "\n").replace('\r', "\n")
 }
 
-pub(super) fn fix_fullwidth_spaces(content: &str) -> (String, Vec<Problem>) {
+pub(super) fn fix_fullwidth_spaces(content: &str, line_map: &[usize]) -> (String, Vec<Problem>) {
     let problems: Vec<Problem> = content
         .lines()
         .enumerate()
@@ -24,7 +24,7 @@ pub(super) fn fix_fullwidth_spaces(content: &str) -> (String, Vec<Problem>) {
             let count = line.chars().filter(|&c| c == FULLWIDTH_SPACE).count();
             std::iter::repeat_n(
                 Problem {
-                    line: line_idx + 1,
+                    line: line_map[line_idx],
                     kind: ProblemKind::FullWidthSpace,
                 },
                 count,
@@ -52,7 +52,15 @@ pub(super) fn normalize_eof_newline(content: &str) -> String {
     format!("{trimmed}\n")
 }
 
-pub(super) fn remove_leading_blank_lines(content: &str) -> (String, Vec<Problem>) {
+/// `line_map[i]` gives the original file line number for line `i` (0-indexed)
+/// of `content`. Fixes that drop or reorder lines return an updated map
+/// alongside their result so downstream problems (from later fixes or
+/// detections) can report the real line the user has open, not the
+/// post-fix line (issue #76).
+pub(super) fn remove_leading_blank_lines(
+    content: &str,
+    line_map: &[usize],
+) -> (String, Vec<usize>, Vec<Problem>) {
     let lines: Vec<&str> = content.lines().collect();
     let first_non_blank = lines
         .iter()
@@ -61,7 +69,7 @@ pub(super) fn remove_leading_blank_lines(content: &str) -> (String, Vec<Problem>
 
     let problems = if first_non_blank > 0 {
         vec![Problem {
-            line: 1,
+            line: line_map[0],
             kind: ProblemKind::LeadingBlankLines {
                 count: first_non_blank,
             },
@@ -73,13 +81,19 @@ pub(super) fn remove_leading_blank_lines(content: &str) -> (String, Vec<Problem>
     let result = lines
         .get(first_non_blank..)
         .map_or(String::new(), |rest| rest.join("\n"));
+    let new_line_map = line_map[first_non_blank.min(line_map.len())..].to_vec();
 
-    (result, problems)
+    (result, new_line_map, problems)
 }
 
-pub(super) fn limit_consecutive_blank_lines(content: &str, max: usize) -> (String, Vec<Problem>) {
+pub(super) fn limit_consecutive_blank_lines(
+    content: &str,
+    max: usize,
+    line_map: &[usize],
+) -> (String, Vec<usize>, Vec<Problem>) {
     let mut problems = vec![];
     let mut result_lines = vec![];
+    let mut new_line_map = vec![];
     let mut blank_count = 0;
     let mut problem_start_line = 0;
 
@@ -88,8 +102,9 @@ pub(super) fn limit_consecutive_blank_lines(content: &str, max: usize) -> (Strin
             blank_count += 1;
             if blank_count <= max {
                 result_lines.push(line);
+                new_line_map.push(line_map[line_idx]);
             } else if blank_count == max + 1 {
-                problem_start_line = line_idx + 1;
+                problem_start_line = line_map[line_idx];
             }
         } else {
             if blank_count > max {
@@ -103,6 +118,7 @@ pub(super) fn limit_consecutive_blank_lines(content: &str, max: usize) -> (Strin
             }
             blank_count = 0;
             result_lines.push(line);
+            new_line_map.push(line_map[line_idx]);
         }
     }
 
@@ -116,12 +132,16 @@ pub(super) fn limit_consecutive_blank_lines(content: &str, max: usize) -> (Strin
         });
     }
 
-    (result_lines.join("\n"), problems)
+    (result_lines.join("\n"), new_line_map, problems)
 }
 
-pub(super) fn remove_code_block_remnants(content: &str) -> (String, Vec<Problem>) {
+pub(super) fn remove_code_block_remnants(
+    content: &str,
+    line_map: &[usize],
+) -> (String, Vec<usize>, Vec<Problem>) {
     let mut problems = vec![];
     let mut result_lines = vec![];
+    let mut new_line_map = vec![];
 
     for (line_idx, line) in content.lines().enumerate() {
         let trimmed = line.trim();
@@ -134,7 +154,7 @@ pub(super) fn remove_code_block_remnants(content: &str) -> (String, Vec<Problem>
 
             if is_valid_fence {
                 problems.push(Problem {
-                    line: line_idx + 1,
+                    line: line_map[line_idx],
                     kind: ProblemKind::CodeBlockRemnant,
                 });
                 continue;
@@ -142,12 +162,13 @@ pub(super) fn remove_code_block_remnants(content: &str) -> (String, Vec<Problem>
         }
 
         result_lines.push(line);
+        new_line_map.push(line_map[line_idx]);
     }
 
-    (result_lines.join("\n"), problems)
+    (result_lines.join("\n"), new_line_map, problems)
 }
 
-pub(super) fn remove_zero_width_chars(content: &str) -> (String, Vec<Problem>) {
+pub(super) fn remove_zero_width_chars(content: &str, line_map: &[usize]) -> (String, Vec<Problem>) {
     let mut problems = vec![];
     let mut result = String::with_capacity(content.len());
     let mut char_idx = 0;
@@ -159,7 +180,7 @@ pub(super) fn remove_zero_width_chars(content: &str) -> (String, Vec<Problem>) {
 
             if is_zero_width && !is_bom_at_start {
                 problems.push(Problem {
-                    line: line_idx + 1,
+                    line: line_map[line_idx],
                     kind: ProblemKind::ZeroWidthCharacter,
                 });
             } else {

--- a/src/normalize/fix.rs
+++ b/src/normalize/fix.rs
@@ -81,7 +81,7 @@ pub(super) fn remove_leading_blank_lines(
     let result = lines
         .get(first_non_blank..)
         .map_or(String::new(), |rest| rest.join("\n"));
-    let new_line_map = line_map[first_non_blank.min(line_map.len())..].to_vec();
+    let new_line_map = line_map[first_non_blank..].to_vec();
 
     (result, new_line_map, problems)
 }

--- a/src/normalize/ignore.rs
+++ b/src/normalize/ignore.rs
@@ -52,9 +52,12 @@ pub(super) fn parse_ignore_directives(content: &str, line_map: &[usize]) -> Igno
 
     for (idx, line) in content.lines().enumerate() {
         let line_num = line_map[idx];
-        // Best-effort original line number for the line right after this one;
-        // if there's no such line (directive on the last line of the file),
-        // this key won't match any real problem.
+        // Best-effort original line number for the line right after this one
+        // (in `content`, i.e. the surviving line, not necessarily original
+        // line_num + 1 — a fini:ignore-next-line directive immediately
+        // followed by a line a fix removed, e.g. a code fence, targets a line
+        // that no longer exists in `content` by the time this runs, so it
+        // can't be recovered here; unmatched key if there's no next line).
         let next_line_num = line_map.get(idx + 1).copied().unwrap_or(line_num + 1);
 
         if let Some(pos) = line.find(NEXT_LINE_DIRECTIVE) {

--- a/src/normalize/ignore.rs
+++ b/src/normalize/ignore.rs
@@ -41,18 +41,26 @@ impl IgnoreMap {
     }
 }
 
-pub(super) fn parse_ignore_directives(content: &str) -> IgnoreMap {
+/// `line_map[i]` gives the original file line number for line `i` (0-indexed)
+/// of `content`, mirroring the same map threaded through the fix pipeline —
+/// `Problem.line` is remapped to original line numbers by the time this runs,
+/// so directives must key on original line numbers too (issue #76).
+pub(super) fn parse_ignore_directives(content: &str, line_map: &[usize]) -> IgnoreMap {
     let mut map = IgnoreMap {
         ignores: HashMap::new(),
     };
 
     for (idx, line) in content.lines().enumerate() {
-        let line_num = idx + 1;
+        let line_num = line_map[idx];
+        // Best-effort original line number for the line right after this one;
+        // if there's no such line (directive on the last line of the file),
+        // this key won't match any real problem.
+        let next_line_num = line_map.get(idx + 1).copied().unwrap_or(line_num + 1);
 
         if let Some(pos) = line.find(NEXT_LINE_DIRECTIVE) {
             map.insert(line_num, None);
             let kinds = parse_kind_list(line, pos + NEXT_LINE_DIRECTIVE.len());
-            map.insert(line_num + 1, kinds);
+            map.insert(next_line_num, kinds);
         } else if let Some(pos) = line.find(DIRECTIVE) {
             let kinds = parse_kind_list(line, pos + DIRECTIVE.len());
             map.insert(line_num, kinds);
@@ -95,10 +103,14 @@ fn parse_kind_list(line: &str, offset: usize) -> Option<HashSet<String>> {
 mod tests {
     use super::*;
 
+    fn identity_map(content: &str) -> Vec<usize> {
+        (1..=content.lines().count()).collect()
+    }
+
     #[test]
     fn ignore_all_same_line() {
         let content = "// TODO: fix this fini:ignore\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         assert!(map.is_ignored(1, &ProblemKind::DebugCode { pattern: "print(" }));
     }
@@ -106,7 +118,7 @@ mod tests {
     #[test]
     fn ignore_selective_same_line() {
         let content = "console.log('x'); // TODO: fix fini:ignore debug\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(
             1,
             &ProblemKind::DebugCode {
@@ -119,7 +131,7 @@ mod tests {
     #[test]
     fn ignore_multiple_kinds() {
         let content = "// fini:ignore todo,debug,secret\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         assert!(map.is_ignored(1, &ProblemKind::DebugCode { pattern: "dbg!(" }));
         assert!(map.is_ignored(1, &ProblemKind::SecretPattern { hint: "key" }));
@@ -129,7 +141,7 @@ mod tests {
     #[test]
     fn ignore_kinds_with_spaces() {
         let content = "// fini:ignore todo , debug\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         assert!(map.is_ignored(1, &ProblemKind::DebugCode { pattern: "print(" }));
     }
@@ -137,7 +149,7 @@ mod tests {
     #[test]
     fn ignore_next_line_all() {
         let content = "// fini:ignore-next-line\n// TODO: fix this\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         assert!(map.is_ignored(2, &ProblemKind::TodoComment));
         assert!(map.is_ignored(2, &ProblemKind::DebugCode { pattern: "dbg!(" }));
@@ -146,7 +158,7 @@ mod tests {
     #[test]
     fn ignore_next_line_selective() {
         let content = "# fini:ignore-next-line debug,secret\nprint('hello')\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(2, &ProblemKind::DebugCode { pattern: "print(" }));
         assert!(map.is_ignored(2, &ProblemKind::SecretPattern { hint: "key" }));
         assert!(!map.is_ignored(2, &ProblemKind::TodoComment));
@@ -155,28 +167,28 @@ mod tests {
     #[test]
     fn hash_comment_style() {
         let content = "# TODO: something fini:ignore\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
     }
 
     #[test]
     fn block_comment_style() {
         let content = "/* TODO: something fini:ignore */\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
     }
 
     #[test]
     fn html_comment_style() {
         let content = "<!-- TODO: something fini:ignore -->\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
     }
 
     #[test]
     fn block_comment_selective() {
         let content = "/* fini:ignore todo */\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         assert!(!map.is_ignored(1, &ProblemKind::FixmeComment));
     }
@@ -184,21 +196,21 @@ mod tests {
     #[test]
     fn directive_line_self_suppresses() {
         let content = "// fini:ignore-next-line todo\nsome code\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
     }
 
     #[test]
     fn unknown_kind_silently_ignored() {
         let content = "// fini:ignore unknown,todo\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
     }
 
     #[test]
     fn ignore_next_line_at_end_of_file() {
         let content = "// fini:ignore-next-line\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         // Should not panic; directive line self-suppresses
         assert!(map.is_ignored(1, &ProblemKind::TodoComment));
         // Line 2 entry exists but is harmless — no problems will reference it
@@ -208,7 +220,7 @@ mod tests {
     #[test]
     fn multiple_directives_merge() {
         let content = "// fini:ignore-next-line todo\n// FIXME: broken fini:ignore fixme\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(2, &ProblemKind::TodoComment));
         assert!(map.is_ignored(2, &ProblemKind::FixmeComment));
         assert!(!map.is_ignored(2, &ProblemKind::DebugCode { pattern: "print(" }));
@@ -217,7 +229,7 @@ mod tests {
     #[test]
     fn ignore_all_wins_over_selective() {
         let content = "// fini:ignore-next-line\n// TODO: fix fini:ignore todo\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(2, &ProblemKind::TodoComment));
         assert!(map.is_ignored(2, &ProblemKind::DebugCode { pattern: "print(" }));
     }
@@ -225,7 +237,7 @@ mod tests {
     #[test]
     fn no_directives_returns_empty() {
         let content = "// just a comment\nfn main() {}\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_empty());
     }
 
@@ -233,7 +245,7 @@ mod tests {
     fn line_length_ignore() {
         let content =
             "let x = \"a very long string that exceeds the limit\"; // fini:ignore line-length\n";
-        let map = parse_ignore_directives(content);
+        let map = parse_ignore_directives(content, &identity_map(content));
         assert!(map.is_ignored(
             1,
             &ProblemKind::LongLine {

--- a/src/normalize/ignore.rs
+++ b/src/normalize/ignore.rs
@@ -52,13 +52,12 @@ pub(super) fn parse_ignore_directives(content: &str, line_map: &[usize]) -> Igno
 
     for (idx, line) in content.lines().enumerate() {
         let line_num = line_map[idx];
-        // Best-effort original line number for the line right after this one
-        // (in `content`, i.e. the surviving line, not necessarily original
-        // line_num + 1 — a fini:ignore-next-line directive immediately
-        // followed by a line a fix removed, e.g. a code fence, targets a line
-        // that no longer exists in `content` by the time this runs, so it
-        // can't be recovered here; unmatched key if there's no next line).
-        let next_line_num = line_map.get(idx + 1).copied().unwrap_or(line_num + 1);
+        // The user's literal next line, per the README ("suppress all
+        // detections on the next line") — not the next surviving line in
+        // `content`. If a fix removed that line (e.g. a code fence), the
+        // directive simply matches no problem, rather than reaching past it
+        // to whatever line took its place.
+        let next_line_num = line_num + 1;
 
         if let Some(pos) = line.find(NEXT_LINE_DIRECTIVE) {
             map.insert(line_num, None);

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -124,31 +124,44 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
 
     result = normalize_line_endings(&result);
 
+    // Maps each line of `result` (0-indexed) to its original file line number
+    // (1-indexed). Fixes that drop or reorder lines update this map so every
+    // problem — from fixes and from detections that run later on the fully
+    // normalized content — reports the line the user actually has open,
+    // rather than a post-fix line number (issue #76).
+    let mut line_map: Vec<usize> = (1..=result.lines().count()).collect();
+
     if config.remove_zero_width {
-        let (fixed, zw_problems) = remove_zero_width_chars(&result);
+        let (fixed, zw_problems) = remove_zero_width_chars(&result, &line_map);
         result = fixed;
         problems.extend(zw_problems);
     }
 
     if config.fix_code_blocks {
-        let (fixed, code_block_problems) = remove_code_block_remnants(&result);
+        let (fixed, new_line_map, code_block_problems) =
+            remove_code_block_remnants(&result, &line_map);
         result = fixed;
+        line_map = new_line_map;
         problems.extend(code_block_problems);
     }
 
     if config.remove_leading_blanks {
-        let (fixed, leading_problems) = remove_leading_blank_lines(&result);
+        let (fixed, new_line_map, leading_problems) =
+            remove_leading_blank_lines(&result, &line_map);
         result = fixed;
+        line_map = new_line_map;
         problems.extend(leading_problems);
     }
 
     if let Some(max) = config.max_blank_lines {
-        let (fixed, blank_problems) = limit_consecutive_blank_lines(&result, max);
+        let (fixed, new_line_map, blank_problems) =
+            limit_consecutive_blank_lines(&result, max, &line_map);
         result = fixed;
+        line_map = new_line_map;
         problems.extend(blank_problems);
     }
 
-    let (fixed, fullwidth_problems) = fix_fullwidth_spaces(&result);
+    let (fixed, fullwidth_problems) = fix_fullwidth_spaces(&result, &line_map);
     result = fixed;
     problems.extend(fullwidth_problems);
 
@@ -156,7 +169,7 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
     result = normalize_eof_newline(&result);
 
     if config.detect_todos || config.detect_fixmes {
-        let (todo_problems, fixme_problems) = detect_todo_and_fixme_comments(&result);
+        let (todo_problems, fixme_problems) = detect_todo_and_fixme_comments(&result, &line_map);
         if config.detect_todos {
             problems.extend(todo_problems);
         }
@@ -166,21 +179,21 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
     }
 
     if config.detect_debug {
-        problems.extend(detect_debug_code(&result, config.strict_debug));
+        problems.extend(detect_debug_code(&result, config.strict_debug, &line_map));
     }
 
     if config.detect_secrets {
-        problems.extend(detect_secret_patterns(&result));
+        problems.extend(detect_secret_patterns(&result, &line_map));
     }
 
     if let Some(max_length) = config.max_line_length {
-        problems.extend(check_line_length(&result, max_length));
+        problems.extend(check_line_length(&result, max_length, &line_map));
     }
 
     // Partition (not filter) so suppressed problems stay auditable (issue #46)
     let mut suppressed = vec![];
     if !problems.is_empty() {
-        let ignore_map = ignore::parse_ignore_directives(&result);
+        let ignore_map = ignore::parse_ignore_directives(&result, &line_map);
         if !ignore_map.is_empty() {
             let (sup, kept): (Vec<_>, Vec<_>) = problems
                 .into_iter()
@@ -1210,5 +1223,41 @@ mod tests {
         let result = normalize_content(input, &NormalizeConfig::default());
         assert_eq!(result.problems.len(), 1);
         assert!(matches!(result.problems[0].kind, ProblemKind::TodoComment));
+    }
+
+    #[test]
+    fn test_detection_line_number_reports_original_line_after_leading_blanks_removed() {
+        // Regression test for issue #76: detections run on the post-fix
+        // content, but --check never writes, so the reported line must match
+        // the original file the user has open, not the shifted content.
+        let input = "\n\n\n// TODO: fix this\n";
+        let result = normalize_content(input, &NormalizeConfig::default());
+        let problem = result
+            .problems
+            .iter()
+            .find(|p| matches!(p.kind, ProblemKind::TodoComment));
+        assert!(problem.is_some());
+        assert_eq!(problem.unwrap().line, 4);
+    }
+
+    #[test]
+    fn test_detection_line_number_reports_original_line_after_code_block_and_blank_shift() {
+        // Combines two line-shifting fixes (code block remnant removal, then
+        // blank-line limiting) ahead of a detection, to make sure line-map
+        // updates compose correctly across fix stages (issue #76).
+        let config = NormalizeConfig {
+            fix_code_blocks: true,
+            max_blank_lines: Some(0),
+            ..NormalizeConfig::default()
+        };
+        // original lines: 1 ```rust  2 fn main() {}  3 (blank)  4 (blank)  5 // TODO: fix
+        let input = "```rust\nfn main() {}\n\n\n// TODO: fix\n";
+        let result = normalize_content(input, &config);
+        let problem = result
+            .problems
+            .iter()
+            .find(|p| matches!(p.kind, ProblemKind::TodoComment));
+        assert!(problem.is_some());
+        assert_eq!(problem.unwrap().line, 5);
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -242,6 +242,26 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_directive_suppressed_line_uses_original_number_after_shift() {
+        let input = "\n\npassword = \"supersecret123\" # fini:ignore secret\n";
+        let result = normalize_content(input, &NormalizeConfig::default());
+        assert_eq!(result.suppressed.len(), 1);
+        assert_eq!(result.suppressed[0].line, 3);
+    }
+
+    #[test]
+    fn test_ignore_next_line_targets_literal_next_line_after_shift() {
+        let input = "\n\n// fini:ignore-next-line\n// TODO: x\n";
+        let result = normalize_content(input, &NormalizeConfig::default());
+        assert!(result
+            .problems
+            .iter()
+            .all(|p| !matches!(p.kind, ProblemKind::TodoComment)));
+        assert_eq!(result.suppressed.len(), 1);
+        assert_eq!(result.suppressed[0].line, 4);
+    }
+
+    #[test]
     fn test_no_directives_leaves_suppressed_empty() {
         let input = "// TODO: fix this\n";
         let result = normalize_content(input, &NormalizeConfig::default());

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -165,6 +165,10 @@ pub fn normalize_content(content: &str, config: &NormalizeConfig) -> NormalizeRe
     result = fixed;
     problems.extend(fullwidth_problems);
 
+    // `line_map` is no longer updated past this point: none of the remaining
+    // fixes may remove or reorder a non-trailing line without threading a new
+    // map through, the same way the fixes above do. Trailing-newline
+    // collapsing below is fine as-is since it only shortens the tail.
     result = remove_trailing_whitespace(&result);
     result = normalize_eof_newline(&result);
 
@@ -1238,6 +1242,22 @@ mod tests {
             .find(|p| matches!(p.kind, ProblemKind::TodoComment));
         assert!(problem.is_some());
         assert_eq!(problem.unwrap().line, 4);
+    }
+
+    #[test]
+    fn test_fullwidth_space_line_number_reports_original_line_after_leading_blanks_removed() {
+        // Same regression as the TODO case above, but for a problem that
+        // itself comes out of a fix pass (not a detector) — fix_fullwidth_spaces
+        // runs after leading-blank removal, so it must consult the shifted
+        // line_map too, not just the final detectors (issue #76).
+        let input = "\n\nhello\u{3000}world\n";
+        let result = normalize_content(input, &NormalizeConfig::default());
+        let problem = result
+            .problems
+            .iter()
+            .find(|p| p.kind == ProblemKind::FullWidthSpace);
+        assert!(problem.is_some());
+        assert_eq!(problem.unwrap().line, 3);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -801,6 +801,31 @@ fn test_check_mode_reports_extra_trailing_newlines_with_crlf() {
 }
 
 #[test]
+fn test_check_mode_reports_original_line_number_after_leading_blanks_removed() {
+    // Regression test for issue #76: detection line numbers must refer to the
+    // original file the user has open, not the post-fix content. `--check`
+    // never writes, so a line number shifted by the (unapplied) leading-blank
+    // fix is simply wrong.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("c.txt");
+    fs::write(&file, "\n\n\n// TODO: fix this\n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--check")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TODO comment at line 4"),
+        "expected TODO reported at original line 4, got: {stdout}"
+    );
+}
+
+#[test]
 fn test_exit_code_2_on_invalid_exclude_pattern() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary
- `--check` (and the `fini:ignore` audit log) reported detection line numbers from the post-fix content, not the original file — a real mismatch since `--check` never writes. Fixes #76.
- Threads a `line_map` (post-fix line index -> original file line number) through the fix pipeline. Every fix that drops or reorders lines (leading-blank removal, blank-line limiting, code block remnant removal) updates the map; every `Problem`-producing function (including fullwidth-space/zero-width fixes and the TODO/FIXME/debug/secret/line-length detectors) looks up the original line through the map instead of using its own local line index.
- `fini:ignore` directive parsing now keys on the same original-line-number space so suppression matching still lines up with the remapped `Problem`s.

## Test plan
- [x] `cargo test` — 178 unit tests + 59 integration tests pass, including two new regression tests (`test_detection_line_number_reports_original_line_after_leading_blanks_removed`, `test_detection_line_number_reports_original_line_after_code_block_and_blank_shift` in `normalize/mod.rs`, and `test_check_mode_reports_original_line_number_after_leading_blanks_removed` in `tests/integration.rs`) that reproduce the exact repro from the issue and fail on the pre-fix code.
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd