### PR TITLE
fix(walker): dedup overlapping path arguments before processing

### DIFF
--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,7 +1,8 @@
 use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
+use std::collections::HashSet;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Walk paths and yield file paths, respecting gitignore and custom exclude patterns.
 ///
@@ -16,6 +17,10 @@ pub fn walk_paths(
     exclude_patterns: &[String],
 ) -> io::Result<impl Iterator<Item = io::Result<PathBuf>>> {
     let mut all_files = vec![];
+    // Overlapping path arguments (e.g. `fini src src/a.rs`) can walk the same
+    // file more than once; dedup so it's only ever processed once (issue
+    // #81). See `dedup_key` for the key used.
+    let mut seen = HashSet::new();
 
     for path in paths {
         let mut builder = WalkBuilder::new(path);
@@ -44,7 +49,10 @@ pub fn walk_paths(
             match entry {
                 Ok(entry) => {
                     if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
-                        all_files.push(Ok(entry.into_path()));
+                        let entry_path = entry.into_path();
+                        if seen.insert(dedup_key(&entry_path)) {
+                            all_files.push(Ok(entry_path));
+                        }
                     }
                 }
                 Err(e) => {
@@ -55,6 +63,24 @@ pub fn walk_paths(
     }
 
     Ok(all_files.into_iter())
+}
+
+/// Dedup key for a walked file: the canonicalized parent directory joined
+/// with the entry's own (non-canonicalized) file name, so the final path
+/// component is never resolved through a symlink. Falls back to the literal
+/// path when the parent can't be canonicalized (e.g. it vanished mid-walk).
+fn dedup_key(path: &Path) -> PathBuf {
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    match parent.canonicalize() {
+        Ok(canon_parent) => match path.file_name() {
+            Some(name) => canon_parent.join(name),
+            None => canon_parent,
+        },
+        Err(_) => path.to_path_buf(),
+    }
 }
 
 #[cfg(test)]
@@ -183,6 +209,89 @@ mod tests {
 
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("app.js"));
+    }
+
+    #[test]
+    fn test_overlapping_dir_and_file_args_dedup_to_one() {
+        // Regression test for issue #81.
+        let dir = TempDir::new().unwrap();
+        let subdir = dir.path().join("dupdir");
+        fs::create_dir(&subdir).unwrap();
+        let file_path = subdir.join("f.txt");
+        fs::write(&file_path, "hello").unwrap();
+
+        let paths = vec![
+            subdir.to_string_lossy().to_string(),
+            file_path.to_string_lossy().to_string(),
+        ];
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert_eq!(
+            files.len(),
+            1,
+            "duplicate path args must collapse: {files:?}"
+        );
+    }
+
+    #[test]
+    fn test_dotdot_path_and_plain_path_dedup_to_one() {
+        // "dupdir" and "dupdir/../dupdir" name the same directory but aren't
+        // `==` as `PathBuf`s (unlike an interior "/./", "/../" is not
+        // normalized away by `Path`'s component comparison), so this only
+        // passes if the dedup key actually canonicalizes.
+        let dir = TempDir::new().unwrap();
+        let subdir = dir.path().join("dupdir");
+        fs::create_dir(&subdir).unwrap();
+        fs::write(subdir.join("f.txt"), "hello").unwrap();
+
+        let paths = vec![
+            subdir.to_string_lossy().to_string(),
+            format!("{}/../dupdir", subdir.to_string_lossy()),
+        ];
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert_eq!(
+            files.len(),
+            1,
+            "equivalent dir args must collapse: {files:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_and_target_are_not_deduped_together() {
+        // A dedup key built from a full canonicalize() of the entry would
+        // resolve link.txt to target.txt and silently drop one of them. The
+        // dedup key must only canonicalize the parent directory, never the
+        // final path component, so a symlink and its target remain distinct
+        // walk results.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link.txt");
+        fs::write(&target, "hello").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Link listed first, matching the order a shell glob would produce.
+        let paths = vec![
+            link.to_string_lossy().to_string(),
+            target.to_string_lossy().to_string(),
+        ];
+        let files: Vec<_> = walk_paths(&paths, &[])
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert_eq!(
+            files.len(),
+            2,
+            "a symlink root and its target are distinct paths, not duplicates: {files:?}"
+        );
     }
 
     #[test]

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,6 +1,6 @@
 use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -21,6 +21,9 @@ pub fn walk_paths(
     // file more than once; dedup so it's only ever processed once (issue
     // #81). See `dedup_key` for the key used.
     let mut seen = HashSet::new();
+    // Caches each parent directory's canonicalize() result so a directory
+    // with many files pays that syscall once, not once per file.
+    let mut canon_parent_cache = HashMap::new();
 
     for path in paths {
         let mut builder = WalkBuilder::new(path);
@@ -50,7 +53,7 @@ pub fn walk_paths(
                 Ok(entry) => {
                     if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                         let entry_path = entry.into_path();
-                        if seen.insert(dedup_key(&entry_path)) {
+                        if seen.insert(dedup_key(&entry_path, &mut canon_parent_cache)) {
                             all_files.push(Ok(entry_path));
                         }
                     }
@@ -68,18 +71,32 @@ pub fn walk_paths(
 /// Dedup key for a walked file: the canonicalized parent directory joined
 /// with the entry's own (non-canonicalized) file name, so the final path
 /// component is never resolved through a symlink. Falls back to the literal
-/// path when the parent can't be canonicalized (e.g. it vanished mid-walk).
-fn dedup_key(path: &Path) -> PathBuf {
+/// path when the parent can't be canonicalized (e.g. it vanished mid-walk) —
+/// the worst case is then a duplicate entry (pre-fix behavior), never a
+/// dropped file, so failing this way is safe.
+///
+/// `cache` memoizes each literal parent's canonicalize() result (`None` on
+/// failure) so a directory with many files pays that syscall once rather
+/// than once per file.
+///
+/// Known limitation: the file-name component is compared literally, so on a
+/// case-insensitive filesystem (default macOS/Windows) two args differing
+/// only in case (`A.rs` vs `a.rs`) that name the same file are not deduped.
+fn dedup_key(path: &Path, cache: &mut HashMap<PathBuf, Option<PathBuf>>) -> PathBuf {
     let parent = match path.parent() {
         Some(p) if !p.as_os_str().is_empty() => p,
         _ => Path::new("."),
     };
-    match parent.canonicalize() {
-        Ok(canon_parent) => match path.file_name() {
+    let canon_parent = cache
+        .entry(parent.to_path_buf())
+        .or_insert_with(|| parent.canonicalize().ok())
+        .clone();
+    match canon_parent {
+        Some(canon_parent) => match path.file_name() {
             Some(name) => canon_parent.join(name),
             None => canon_parent,
         },
-        Err(_) => path.to_path_buf(),
+        None => path.to_path_buf(),
     }
 }
 
@@ -88,6 +105,13 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_dedup_key_falls_back_to_literal_path_when_parent_missing() {
+        let mut cache = HashMap::new();
+        let path = Path::new("/definitely/nonexistent/dir/f.txt");
+        assert_eq!(dedup_key(path, &mut cache), path.to_path_buf());
+    }
 
     #[test]
     fn test_walk_single_file() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1290,6 +1290,74 @@ fn test_symlink_target_never_rewritten() {
 }
 
 // ===========================================
+// Overlapping Path Arguments (issue #81)
+// ===========================================
+
+#[test]
+fn test_overlapping_dir_and_file_args_fix_once() {
+    let dir = TempDir::new().unwrap();
+    let subdir = dir.path().join("dupdir");
+    fs::create_dir(&subdir).unwrap();
+    let file = subdir.join("f.txt");
+    fs::write(&file, "hello   \n").unwrap();
+
+    let output = fini_cmd()
+        .arg(subdir.to_str().unwrap())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(!stderr.contains("changed on disk"), "stderr: {stderr}");
+    assert_eq!(
+        stdout.matches("Fixed:").count(),
+        1,
+        "file named by two overlapping path args must be fixed exactly once: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 files fixed"),
+        "summary must count the file once: {stdout}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_overlapping_dir_and_file_args_check_mode_counts_once() {
+    let dir = TempDir::new().unwrap();
+    let subdir = dir.path().join("dupdir");
+    fs::create_dir(&subdir).unwrap();
+    let file = subdir.join("f.txt");
+    fs::write(&file, "hello   \n").unwrap();
+
+    let output = fini_cmd()
+        .arg("--check")
+        .arg(subdir.to_str().unwrap())
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(1), "stdout: {stdout}");
+    assert_eq!(
+        stdout.matches("f.txt").count(),
+        1,
+        "file named by two overlapping path args must be reported exactly once: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 files with problems"),
+        "summary must count the file once: {stdout}"
+    );
+    // File must be untouched in check mode.
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello   \n");
+}
+
+// ===========================================
 // Stdin Mode
 // ===========================================
 


### PR DESCRIPTION
## Summary
- Overlapping path arguments (e.g. `fini src src/a.rs`) walked the same file twice; both copies were read and written in the same parallel chunk, and the second write always failed the issue #35 "changed on disk" freshness guard, producing a bogus error and exit 2.
- Fixes #81 by deduping walked files in `walk_paths` by a key of (canonicalized parent directory, literal file name) — not a full `canonicalize()` of the entry, which would incorrectly collapse a symlink root with its target and silently drop whichever was named second.

## Test plan
- [x] `cargo test` — full suite (179 lib tests + 60 integration tests) green, including new regression tests: fix mode fixes the file exactly once and exits 0, check mode counts the file once, walker unit tests cover directory+file overlap, `../`-normalized path equivalence, and (unix) a symlink + its target remaining two distinct entries.
- [x] `cargo clippy` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manually verified the original repro (`fini dupdir dupdir/f.txt`) now fixes once and exits 0, and the symlink-root edge case (`fini link.txt target.txt`) still fixes `target.txt` without dropping it.

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd