### PR TITLE
fix(vscode): stop corrupting multi-byte stdout at chunk boundaries

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 node_modules/**
 src/**
+test/**
 tsconfig.json
 *.map
 .gitignore

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -77,6 +77,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "watch": "npm run compile -- --watch",
+    "test": "node --test",
     "package": "vsce package",
     "publish": "vsce publish"
   },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -10,7 +10,8 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.85.0",
+    "node": ">=22.18.0"
   },
   "categories": [
     "Formatters",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
+import { collectOutput } from './procOutput';
 
 let outputChannel: vscode.OutputChannel;
 
@@ -62,16 +63,13 @@ function compareVersions(a: [number, number, number], b: [number, number, number
 
 function checkCliCompatibility(finiPath: string) {
     const proc = spawn(finiPath, ['--version']);
-
-    let stdout = '';
-    proc.stdout.on('data', (data) => {
-        stdout += data.toString();
-    });
+    const output = collectOutput(proc);
 
     proc.on('close', (code) => {
         if (code !== 0) {
             return;
         }
+        const stdout = output.stdout();
         // `fini X.Y.Z` — shape covered by the CLI's version-output test
         const match = stdout.trim().match(/^fini (\d+)\.(\d+)\.(\d+)/);
         if (!match) {
@@ -115,18 +113,12 @@ async function formatDocument(document: vscode.TextDocument): Promise<vscode.Tex
             cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
         });
 
-        let stdout = '';
-        let stderr = '';
-
-        proc.stdout.on('data', (data) => {
-            stdout += data.toString();
-        });
-
-        proc.stderr.on('data', (data) => {
-            stderr += data.toString();
-        });
+        const output = collectOutput(proc);
 
         proc.on('close', (code) => {
+            const stdout = output.stdout();
+            const stderr = output.stderr();
+
             if (code !== 0) {
                 outputChannel.appendLine(`fini exited with code ${code}`);
                 if (stderr) {

--- a/editors/vscode/src/procOutput.ts
+++ b/editors/vscode/src/procOutput.ts
@@ -1,0 +1,34 @@
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+
+/**
+ * Collects a child process's stdout/stderr as UTF-8 strings.
+ *
+ * `setEncoding('utf8')` makes each stream use Node's internal StringDecoder,
+ * which buffers a trailing partial multi-byte sequence until the next chunk
+ * arrives instead of decoding each chunk in isolation. Without it, a
+ * multi-byte character split across a chunk boundary (pipes deliver ~64 KiB
+ * chunks, not aligned to UTF-8 character boundaries) gets each half decoded
+ * independently and replaced with U+FFFD.
+ */
+export function collectOutput(proc: ChildProcessWithoutNullStreams): {
+    stdout: () => string;
+    stderr: () => string;
+} {
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.setEncoding('utf8');
+    proc.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+    });
+
+    proc.stderr.setEncoding('utf8');
+    proc.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+    });
+
+    return {
+        stdout: () => stdout,
+        stderr: () => stderr,
+    };
+}

--- a/editors/vscode/test/procOutput.test.mjs
+++ b/editors/vscode/test/procOutput.test.mjs
@@ -1,0 +1,76 @@
+// Regression test for issue #88: reading a child process's stdout via
+// per-chunk `Buffer.toString()` corrupts multi-byte UTF-8 characters that
+// straddle a chunk boundary (pipes deliver ~64 KiB chunks, and 65536 is not
+// a multiple of 3, the byte width of "あ" and similar CJK characters).
+//
+// Uses Node's built-in test runner (`node --test`) so no extra devDependency
+// is needed. Run with: node --test editors/vscode/test/procOutput.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { collectOutput } from '../src/procOutput.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const finiBin = process.env.FINI_BIN || path.join(repoRoot, 'target', 'release', 'fini');
+
+// The buggy pattern this issue fixes: per-chunk toString() with no encoding
+// set on the stream, so each Buffer chunk is decoded independently. Used
+// only to prove the test harness can detect the corruption it's guarding
+// against — production code goes through collectOutput() from procOutput.ts.
+function collectOutputBuggy(proc) {
+    let stdout = '';
+    proc.stdout.on('data', (data) => {
+        stdout += data.toString();
+    });
+    return { stdout: () => stdout };
+}
+
+function runFini(collector) {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(finiBin, ['--stdin'], { cwd: repoRoot });
+        const output = collector(proc);
+
+        proc.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`fini exited with code ${code}`));
+                return;
+            }
+            resolve(output.stdout());
+        });
+        proc.on('error', (err) => {
+            reject(
+                new Error(
+                    `failed to spawn fini at ${finiBin}: ${err.message}. ` +
+                        'Build it first (`cargo build --release`) or point FINI_BIN at a built binary.'
+                )
+            );
+        });
+
+        // stdout arrives from the OS pipe in ~64 KiB chunks regardless of
+        // how stdin is written; fini reads all of stdin before it emits
+        // anything, so a single write is enough to trigger the read-side
+        // chunking that this test guards against.
+        proc.stdin.end(Buffer.from('あ'.repeat(100_000), 'utf8')); // 300,000 bytes
+    });
+}
+
+test('collectOutput (fixed) preserves multi-byte characters split across chunk boundaries', async () => {
+    // fini normalizes EOF newlines, so stdin without a trailing "\n" comes
+    // back with one appended.
+    const expected = `${'あ'.repeat(100_000)}\n`;
+    const stdout = await runFini(collectOutput);
+    assert.equal(stdout, expected);
+    assert.equal(Buffer.byteLength(stdout, 'utf8'), 300_001);
+    assert.equal(stdout.includes('�'), false);
+});
+
+test('collectOutput (buggy per-chunk toString) demonstrates the corruption this fix prevents', async () => {
+    const expected = `${'あ'.repeat(100_000)}\n`;
+    const stdout = await runFini(collectOutputBuggy);
+    assert.notEqual(stdout, expected);
+    assert.ok(stdout.includes('�'), 'expected replacement characters from split multi-byte sequences');
+});


### PR DESCRIPTION
## Summary
- The extension read fini's stdout/stderr by calling `.toString()` on each raw `data` chunk and concatenating strings. Node delivers pipe data in ~64 KiB chunks, and 65536 is not a multiple of 3 (the byte width of many CJK characters), so a multi-byte UTF-8 character straddling a chunk boundary got its byte sequence split and independently decoded on each side, replacing it with U+FFFD — silently corrupting the text written back on save.
- Extracted stdout/stderr collection into `collectOutput()` (`editors/vscode/src/procOutput.ts`), which calls `stream.setEncoding('utf8')` before attaching the `data` handler so Node's internal `StringDecoder` buffers a trailing partial multi-byte sequence across chunks. Applied to both `checkCliCompatibility()` and `formatDocument()` (stdout and stderr).
- Added a regression test (`editors/vscode/test/procOutput.test.mjs`) using Node's built-in test runner (`node --test`, wired via a new `test` script in `editors/vscode/package.json`) — no new devDependency needed since Node 24 strips TS types natively. It spawns the real `fini --stdin` binary with 100,000 "あ" characters (300 KB) and asserts the real `collectOutput()` returns the input byte-for-byte, plus a companion test proving the old buggy per-chunk pattern does produce replacement characters (so the harness is known to detect the corruption).

Fixes #88.

## Test plan
- [x] `npm run test` (in `editors/vscode/`) — both tests pass; confirmed the "fixed" test fails when `setEncoding('utf8')` is reverted, so it's a genuine regression test against the fix
- [x] `npm run compile` — esbuild bundle still succeeds
- [x] `cargo test` — full Rust suite (234 tests) passes, unaffected by this change

https://claude.ai/code/session_018t39xJ6FByaeBXDLJT9PBd